### PR TITLE
starting on autotools...

### DIFF
--- a/GFDL_tools/Makefile.am
+++ b/GFDL_tools/Makefile.am
@@ -1,0 +1,6 @@
+# This is the automake file for GFDL_atmos_cubed_sphere GFDL_tools
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS = GFDL SHiELD

--- a/GFDL_tools/Makefile.am
+++ b/GFDL_tools/Makefile.am
@@ -1,6 +1,27 @@
 # This is the automake file for GFDL_atmos_cubed_sphere GFDL_tools
 # subdirectory.
-# Ed Hartnett 7/22/2019
+# Ed Hartnett 7/24/2019
 
-# Make targets will be run in each subdirectory. Order is significant.
-#SUBDIRS = GFDL SHiELD
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libfv_ada_nudge.la libfv_climate_nudge.la	\
+libfv_cmip_diag.la
+
+# The convenience library depends on its source.
+libfv_climate_nudge_la_SOURCES = fv_climate_nudge.F90
+libfv_cmip_diag_la_SOURCES = fv_cmip_diag.F90
+libfv_ada_nudge_la_SOURCES = fv_ada_nudge.F90
+
+# Mod file depends on its o file, is built and then installed.
+fv_cmip_diag_mod.mod: fv_cmip_diag.$(OBJEXT)
+fv_climate_nudge_mod.mod: fv_climate_nudge.$(OBJEXT)
+fv_ada_nudge_mod.mod: fv_ada_nudge.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+#atmosphere.$(OBJEXT): atmos_co2_mod.mod
+
+MODFILES = fv_cmip_diag_mod.mod fv_climate_nudge_mod.mod	\
+fv_ada_nudge_mod.mod
+BUILT_SOURCES = ${MODFILES}
+include_HEADERS = ${MODFILES}
+
+CLEANFILES = *.mod

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
 # Make targets will be run in each subdirectory. Order is significant.
-#SUBDIRS =
+SUBDIRS = driver GFDL_tools model model_nh tools
 
 EXTRA_DIST = README.md LICENSE.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@
 ACLOCAL_AMFLAGS = -I m4
 
 # Make targets will be run in each subdirectory. Order is significant.
-SUBDIRS = driver GFDL_tools model model_nh tools
+#SUBDIRS = driver GFDL_tools model model_nh tools
+SUBDIRS = GFDL_tools model model_nh tools
 
 EXTRA_DIST = README.md LICENSE.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,10 @@
+# This is the main automake file for GFDL_atmos_cubed_sphere.
+# Ed Hartnett 7/22/2019
+
+# This directory stores libtool macros, put there by aclocal.
+ACLOCAL_AMFLAGS = -I m4
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS =
+
+EXTRA_DIST = README.md LICENSE.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,6 @@ ACLOCAL_AMFLAGS = -I m4
 
 # Make targets will be run in each subdirectory. Order is significant.
 #SUBDIRS = driver GFDL_tools model model_nh tools
-SUBDIRS = GFDL_tools model model_nh tools
+SUBDIRS = model GFDL_tools model_nh tools
 
 EXTRA_DIST = README.md LICENSE.md

--- a/configure.ac
+++ b/configure.ac
@@ -60,5 +60,12 @@ AC_DEFINE([use_libMPI], [1])
 
 # These files will be created when the configure script is run.
 AC_CONFIG_FILES([Makefile
+        GFDL_tools/Makefile
+        driver/GFDL/Makefile
+	driver/Makefile
+	driver/SHiELD/Makefile
+	model/Makefile
+	model_nh/Makefile
+        tools/Makefile
         ])
 AC_OUTPUT()

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,9 @@ AC_SYS_LARGEFILE
 # Require MPI.
 AC_CHECK_FUNC([MPI_Init], [], [AC_MSG_ERROR([MPI C library required])])
 
+# Require FMS. But this does not work because fms_platform.h is actually a fortran file.
+# AC_CHECK_HEADERS([fms_platform.h], [], [AC_MSG_ERROR([Can't find fms_platform.h.])])
+
 dnl # Check for netCDF C library.
 dnl AC_SEARCH_LIBS([nc_create], [netcdf], [],
 dnl                             [AC_MSG_ERROR([Can't find or link to the netcdf C library, set CPPFLAGS/LDFLAGS.])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,64 @@
+# This is the main configure file for the GFDL_atmos_cubed_sphere
+# package.
+# Ed Hartnett 7/22/2019
+
+AC_PREREQ([2.59])
+
+# Initialize with name, version, and support email address.
+AC_INIT([GFDL_atmos_cubed_shere], [2.0-development], [])
+
+# Find out about the host we're building on.
+AC_CANONICAL_HOST
+
+# Find out about the target we're building for.
+AC_CANONICAL_TARGET
+
+AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
+
+# Keep libtool macros in an m4 directory.
+AC_CONFIG_MACRO_DIR([m4])
+
+# Set up libtool.
+LT_PREREQ([2.4])
+LT_INIT()
+
+# Find the C compiler.
+AC_PROG_CC
+AM_PROG_CC_C_O
+AC_C_CONST
+AC_PROG_CPP
+
+# Find the Fortran compiler.
+AC_PROG_FC
+AC_PROG_F77
+
+# Find the install program.
+AC_PROG_INSTALL
+
+# Check to see if any macros must be set to enable large (>2GB) files.
+AC_SYS_LARGEFILE
+
+# Require MPI.
+AC_CHECK_FUNC([MPI_Init], [], [AC_MSG_ERROR([MPI C library required])])
+
+dnl # Check for netCDF C library.
+dnl AC_SEARCH_LIBS([nc_create], [netcdf], [],
+dnl                             [AC_MSG_ERROR([Can't find or link to the netcdf C library, set CPPFLAGS/LDFLAGS.])])
+
+dnl # Check for netCDF Fortran library.
+dnl AC_LANG_PUSH(Fortran)
+dnl AC_SEARCH_LIBS([nf_create], [netcdff], [],
+dnl                             [AC_MSG_ERROR([Can't find or link to the netcdf Fortran library, set CPPFLAGS/LDFLAGS.])])
+dnl AC_LANG_POP(Fortran)
+
+# Require netCDF.
+#AC_CHECK_FUNC([nf_open], [], [AC_MSG_ERROR([NetCDF Fortran library required])])
+
+# These defines are required for the build.
+AC_DEFINE([use_netCDF], [1])
+AC_DEFINE([use_libMPI], [1])
+
+# These files will be created when the configure script is run.
+AC_CONFIG_FILES([Makefile
+        ])
+AC_OUTPUT()

--- a/driver/GFDL/Makefile.am
+++ b/driver/GFDL/Makefile.am
@@ -1,0 +1,6 @@
+# This is the automake file for GFDL_atmos_cubed_sphere driver
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS = GFDL SHiELD

--- a/driver/GFDL/Makefile.am
+++ b/driver/GFDL/Makefile.am
@@ -1,6 +1,24 @@
-# This is the automake file for GFDL_atmos_cubed_sphere driver
-# subdirectory.
-# Ed Hartnett 7/22/2019
+# This is an automake file for the GFDL_atmos_cubed_sphere/driver/GFDL
+# directory.
 
-# Make targets will be run in each subdirectory. Order is significant.
-#SUBDIRS = GFDL SHiELD
+# Ed Hartnett 7/22/19
+
+# Include .h and .mod files.
+# AM_CPPFLAGS = -I${top_srcdir}/include
+# AM_CPPFLAGS += -I${top_builddir}/fms
+# AM_CPPFLAGS += -I${top_builddir}/time_manager
+# AM_CPPFLAGS += -I${top_builddir}/constants
+# AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libatmosphere.la
+
+# The convenience library depends on its source.
+libatmosphere_la_SOURCES = atmosphere.F90
+
+# Mod file depends on its o file, is built and then installed.
+atmosphere_mod.mod: atmosphere.$(OBJEXT)
+BUILT_SOURCES = atmosphere_mod.mod
+include_HEADERS = atmosphere_mod.mod
+
+CLEANFILES = *.mod

--- a/driver/GFDL/Makefile.am
+++ b/driver/GFDL/Makefile.am
@@ -11,14 +11,20 @@
 # AM_CPPFLAGS += -I${top_builddir}/mpp
 
 # Build this uninstalled convenience library.
-noinst_LTLIBRARIES = libatmosphere.la
+noinst_LTLIBRARIES = libatmos_co2.la libatmosphere.la
 
 # The convenience library depends on its source.
 libatmosphere_la_SOURCES = atmosphere.F90
+libatmos_co2_la_SOURCES = atmos_co2.F90
 
 # Mod file depends on its o file, is built and then installed.
 atmosphere_mod.mod: atmosphere.$(OBJEXT)
-BUILT_SOURCES = atmosphere_mod.mod
-include_HEADERS = atmosphere_mod.mod
+atmos_co2_mod.mod: atmos_co2.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+atmosphere.$(OBJEXT): atmos_co2_mod.mod
+
+BUILT_SOURCES = atmosphere_mod.mod atmos_co2_mod.mod
+include_HEADERS = atmosphere_mod.mod atmos_co2_mod.mod
 
 CLEANFILES = *.mod

--- a/driver/Makefile.am
+++ b/driver/Makefile.am
@@ -3,5 +3,5 @@
 # Ed Hartnett 7/22/2019
 
 # Make targets will be run in each subdirectory. Order is significant.
-SUBDIRS = GFDL SHiELD
-
+#SUBDIRS = GFDL SHiELD
+SUBDIRS = SHiELD

--- a/driver/Makefile.am
+++ b/driver/Makefile.am
@@ -1,0 +1,7 @@
+# This is the automake file for GFDL_atmos_cubed_sphere driver
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+SUBDIRS = GFDL SHiELD
+

--- a/driver/SHiELD/Makefile.am
+++ b/driver/SHiELD/Makefile.am
@@ -2,25 +2,25 @@
 # subdirectory.
 # Ed Hartnett 7/24/2019
 
-# Build this uninstalled convenience library.
+# Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = liblin_cld_microphys.la libconstants.la	\
 libatmosphere.la
 
 # The convenience library depends on its source.
 libconstants_la_SOURCES = constants.F90
 libatmosphere_la_SOURCES = atmosphere.F90
-liblin_cld_microphys_la_SOURCES = lin_cld_microphys.F90
+liblin_cld_microphys_la_SOURCES = lin_cloud_microphys.F90
 
 # Mod file depends on its o file, is built and then installed.
 atmosphere_mod.mod: atmosphere.$(OBJEXT)
 constants_mod.mod: constants.$(OBJEXT)
-lin_cloud_microphys_mod.mod: lin_cloud_microphys.$(OBJEXT)
+lin_cld_microphys_mod.mod: lin_cloud_microphys.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
 #atmosphere.$(OBJEXT): atmos_co2_mod.mod
 
 MODFILES = atmosphere_mod.mod constants_mod.mod	\
-lin_cloud_microphys_mod.mod
+lin_cld_microphys_mod.mod
 BUILT_SOURCES = ${MODFILES}
 include_HEADERS = ${MODFILES}
 

--- a/driver/SHiELD/Makefile.am
+++ b/driver/SHiELD/Makefile.am
@@ -1,0 +1,6 @@
+# This is the automake file for GFDL_atmos_cubed_sphere driver
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS = GFDL SHiELD

--- a/driver/SHiELD/Makefile.am
+++ b/driver/SHiELD/Makefile.am
@@ -1,6 +1,27 @@
-# This is the automake file for GFDL_atmos_cubed_sphere driver
+# This is the automake file for GFDL_atmos_cubed_sphere driver/SHIELD
 # subdirectory.
-# Ed Hartnett 7/22/2019
+# Ed Hartnett 7/24/2019
 
-# Make targets will be run in each subdirectory. Order is significant.
-#SUBDIRS = GFDL SHiELD
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = liblin_cld_microphys.la libconstants.la	\
+libatmosphere.la
+
+# The convenience library depends on its source.
+libconstants_la_SOURCES = constants.F90
+libatmosphere_la_SOURCES = atmosphere.F90
+liblin_cld_microphys_la_SOURCES = lin_cld_microphys.F90
+
+# Mod file depends on its o file, is built and then installed.
+atmosphere_mod.mod: atmosphere.$(OBJEXT)
+constants_mod.mod: constants.$(OBJEXT)
+lin_cloud_microphys_mod.mod: lin_cloud_microphys.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+#atmosphere.$(OBJEXT): atmos_co2_mod.mod
+
+MODFILES = atmosphere_mod.mod constants_mod.mod	\
+lin_cloud_microphys_mod.mod
+BUILT_SOURCES = ${MODFILES}
+include_HEADERS = ${MODFILES}
+
+CLEANFILES = *.mod

--- a/model/Makefile.am
+++ b/model/Makefile.am
@@ -1,6 +1,46 @@
-# This is the automake file for GFDL_atmos_cubed_sphere driver
+# This is the automake file for GFDL_atmos_cubed_sphere model
 # subdirectory.
-# Ed Hartnett 7/22/2019
+# Ed Hartnett 7/24/2019
 
-# Make targets will be run in each subdirectory. Order is significant.
-#SUBDIRS = GFDL SHiELD
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = liba2b_edge.la libboundary.la libdyn_core.la	\
+libfv_arrays.la libfv_cmp.la libfv_control.la libfv_current_grid.la	\
+libfv_dynamics.la libfv_fill.la libfv_grid_utils.la libfv_mapz.la	\
+libfv_nesting.la libfv_sg.la libfv_tracer2d.la libfv_update_phys.la	\
+libsw_core.la libtp_core.la
+
+# The convenience libries depends on their source.
+libtp_core_la_SOURCES = tp_core.F90
+libsw_core_la_SOURCES = sw_core.F90
+libfv_update_phys_la_SOURCES = fv_update_phys.F90
+libfv_tracer2d_la_SOURCES = fv_tracer2d.F90
+libfv_sg_la_SOURCES = fv_sg.F90
+libfv_nesting_la_SOURCES = fv_nesting.F90
+libfv_mapz_la_SOURCES = fv_mapz.F90
+libfv_grid_utils_la_SOURCES = fv_grid_utils.F90
+libfv_fill_la_SOURCES = fv_fill.F90
+libfv_dynamics_la_SOURCES = fv_dynamics.F90
+libfv_current_grid_la_SOURCES = fv_current_grid.F90
+libfv_control_la_SOURCES = fv_control.F90
+libfv_cmp_la_SOURCES = fv_cmp.F90
+libfv_arrays_la_SOURCES = fv_arrays.F90
+libdyn_core_la_SOURCES = dyn_core.F90
+libboundary_la_SOURCES = boundary.F90
+liba2b_edge_la_SOURCES = a2b_edge.F90
+
+# Mod file depends on its o file, is built and then installed.
+a2b_edge_mod.mod: a2b_edge.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+#atmosphere.$(OBJEXT): atmos_co2_mod.mod
+
+MODFILES = a2b_edge_mod.mod boundary_mod.mod dyn_core_mod.mod	\
+fv_arrays_mod.mod fv_cmp_mod.mod fv_control_mod.mod		\
+fv_current_grid_mod.mod fv_dynamics_mod.mod fv_fill_mod.mod	\
+fv_grid_utils_mod.mod fv_mapz_mod.mod fv_nesting_mod.mod	\
+fv_sg_mod.mod fv_tracer2d_mod.mod fv_update_phys_mod.mod	\
+sw_core_mod.mod tp_core_mod.mod
+BUILT_SOURCES = ${MODFILES}
+include_HEADERS = ${MODFILES}
+
+CLEANFILES = *.mod

--- a/model/Makefile.am
+++ b/model/Makefile.am
@@ -1,0 +1,6 @@
+# This is the automake file for GFDL_atmos_cubed_sphere driver
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS = GFDL SHiELD

--- a/model_nh/Makefile.am
+++ b/model_nh/Makefile.am
@@ -1,0 +1,6 @@
+# This is the automake file for GFDL_atmos_cubed_sphere driver
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS = GFDL SHiELD

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,6 +1,45 @@
-# This is the automake file for GFDL_atmos_cubed_sphere driver
+# This is the automake file for GFDL_atmos_cubed_sphere tools
 # subdirectory.
-# Ed Hartnett 7/22/2019
+# Ed Hartnett 7/24/2019
 
-# Make targets will be run in each subdirectory. Order is significant.
-#SUBDIRS = GFDL SHiELD
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libexternal_ic.la libexternal_sst.la		\
+libfv_diagnostics.la libfv_eta.la libfv_grid_tools.la libfv_io.la	\
+libfv_mp_mod.la libfv_nggps_diag.la libfv_nudge.la libfv_restart.la	\
+libfv_surf_map.la libfv_timing.la libinit_hydro.la libsim_nc_mod.la	\
+libsorted_index.la libtest_cases.la
+
+#The convenience libries depends on their source.
+libtest_cases_la_SOURCES = test_cases.F90
+libsorted_index_la_SOURCES = sorted_index.F90
+libsim_nc_mod_la_SOURCES = sim_nc_mod.F90
+libinit_hydro_la_SOURCES = init_hydro.F90
+libfv_timing_la_SOURCES = fv_timing.F90
+libfv_surf_map_la_SOURCES = fv_surf_map.F90
+libfv_restart_la_SOURCES = fv_restart.F90
+libfv_nudge_la_SOURCES = fv_nudge.F90
+libfv_nggps_diag_la_SOURCES = fv_nggps_diag.F90
+libfv_mp_mod_la_SOURCES = fv_mp_mod.F90
+libfv_io_la_SOURCES = fv_io.F90
+libfv_grid_tools_la_SOURCES = fv_grid_tools.F90
+libfv_eta_la_SOURCES = fv_eta.F90
+libfv_diagnostics_la_SOURCES = fv_diagnostics.F90
+libexternal_sst_la_SOURCES = external_sst.F90
+libexternal_ic_la_SOURCES = external_ic.F90
+
+# Mod file depends on its o file, is built and then installed.
+external_ic_mod.mod: external_ic.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+#atmosphere.$(OBJEXT): atmos_co2_mod.mod
+
+MODFILES = external_ic_mod.mod external_sst_mod.mod		\
+fv_diagnostics_mod.mod fv_eta_mod.mod fv_grid_tools_mod.mod	\
+fv_io_mod.mod fv_mp_mod_mod.mod fv_nggps_diag_mod.mod		\
+fv_nudge_mod.mod fv_restart_mod.mod fv_surf_map_mod.mod		\
+fv_timing_mod.mod init_hydro_mod.mod sim_nc_mod_mod.mod		\
+sorted_index_mod.mod test_cases_mod.mod
+BUILT_SOURCES = ${MODFILES}
+include_HEADERS = ${MODFILES}
+
+CLEANFILES = *.mod

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,0 +1,6 @@
+# This is the automake file for GFDL_atmos_cubed_sphere driver
+# subdirectory.
+# Ed Hartnett 7/22/2019
+
+# Make targets will be run in each subdirectory. Order is significant.
+#SUBDIRS = GFDL SHiELD


### PR DESCRIPTION
Here's the beginning of the autotools build.

I build this with:
`autoreconf -i && CC=mpicc FC=mpifort CPPFLAGS=-I/usr/local/fms/include LDFLAGS=-L/usr/local/fms/lib ./configure && make clean && make check`

It starts by trying to build in directory driver/GFDL, and fails like this:

```
Making check in GFDL
make[2]: Entering directory '/home/ed/tmp/GFDL_atmos_cubed_sphere/driver/GFDL'
mpifort -DPACKAGE_NAME=\"GFDL_atmos_cubed_shere\" -DPACKAGE_TARNAME=\"gfdl_atmos_cubed_shere\" -DPACKAGE_VERSION=\"2.0-development\" -DPACKAGE_STRING=\"GFDL_atmos_cubed_shere\ 2.0-development\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"gfdl_atmos_cubed_shere\" -DVERSION=\"2.0-development\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -Duse_netCDF=1 -Duse_libMPI=1 -I.   -I/usr/local/fms/include  -g -O2 -c -o atmosphere.o atmosphere.F90
/usr/local/fms/include/fms_platform.h:114:0:

 #define QUAD_KIND DOUBLE_KIND
 
Warning: "QUAD_KIND" redefined
/usr/local/fms/include/fms_platform.h:39:0:

 #define QUAD_KIND 16
 
note: this is the location of the previous definition
atmosphere.F90:33:4:

 use atmos_co2_mod,      only: atmos_co2_rad, co2_radiation_override
    1
Fatal Error: Can't open module file ‘atmos_co2_mod.mod’ for reading at (1): No such file or directory
compilation terminated.
Makefile:405: recipe for target 'atmosphere.o' failed
make[2]: *** [atmosphere.o] Error 1
make[2]: Leaving directory '/home/ed/tmp/GFDL_atmos_cubed_sphere/driver/GFDL'
Makefile:364: recipe for target 'check-recursive' failed
make[1]: *** [check-recursive] Error 1
make[1]: Leaving directory '/home/ed/tmp/GFDL_atmos_cubed_sphere/driver'
Makefile:395: recipe for target 'check-recursive' failed
make: *** [check-recursive] Error 1
```

I cannot find atmos_co2_mod in the FMS package. Where is it?