### PR TITLE
fix GNU out-of-bounds error in a diagnostic in GFDL driver

### DIFF
--- a/driver/GFDL/atmosphere.F90
+++ b/driver/GFDL/atmosphere.F90
@@ -434,7 +434,7 @@ contains
 !miz
    if ( id_tdt_dyn>0 .or. query_cmip_diag_id(ID_tnta) ) ttend(:, :, :) = Atm(mygrid)%pt(isc:iec, jsc:jec, :)
    if ( any((/ id_qdt_dyn, id_qldt_dyn, id_qidt_dyn, id_qadt_dyn /) > 0) .or. &
-        query_cmip_diag_id(ID_tnhusa) ) qtend(:, :, :, :) = Atm(mygrid)%q (isc:iec, jsc:jec, :, :)
+        query_cmip_diag_id(ID_tnhusa) ) qtend(:, :, :, 1:4) = Atm(mygrid)%q (isc:iec, jsc:jec, :, 1:4)
 !miz
    do itrac = 1, num_tracers
      if (id_tracerdt_dyn (itrac) >0 ) &

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -53,7 +53,7 @@ module fv_control_mod
    use fv_mp_mod,           only: mp_start, domain_decomp, mp_assign_gid, global_nest_domain
    use fv_mp_mod,           only: broadcast_domains, mp_barrier, is_master, setup_master, grids_master_procs, tile_fine
    use fv_mp_mod,           only: MAX_NNEST, MAX_NTILE
-   !use test_cases_mod,      only: test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size
+   use test_cases_mod,      only: read_namelist_test_case_nml
    use fv_timing_mod,       only: timing_on, timing_off, timing_init, timing_prt
    use mpp_domains_mod,     only: domain2D
    use mpp_domains_mod,     only: mpp_define_nest_domains, nest_domain_type, mpp_get_global_domain
@@ -432,7 +432,7 @@ module fv_control_mod
 #endif
      call read_namelist_fv_grid_nml
      call read_namelist_fv_core_nml(Atm(this_grid)) ! do options processing here too?
-     !TODO test_case_nml moved to test_cases
+     call read_namelist_test_case_nml(Atm(this_grid)%nml_filename)
      call mpp_get_current_pelist(Atm(this_grid)%pelist, commID=commID) ! for commID
      call mp_start(commID,halo_update_type)
 

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -154,7 +154,7 @@
      integer, parameter :: interpOrder = 1
 
       public :: pz0, zz0
-      public :: test_case, bubble_do, alpha, tracer_test, wind_field, nsolitons, soliton_Umax, soliton_size
+      public :: read_namelist_test_case_nml, alpha
       public :: init_case
       public :: case9_forcing1, case9_forcing2, case51_forcing
       public :: init_double_periodic


### PR DESCRIPTION
Fixes #34 

Fixes a missing namelist for the doubly-periodic model
Fixes a GNU out-of-bounds error in a diagnostic quantity in the GFDL driver (driver/GFDL/atmosphere.F90).

Once this pull request is merged into master, it will be merged into the dev/gfdl branch (already tested for automatic merge).