### PR TITLE
Fix initialization of ??_corner flags

### DIFF
--- a/model/fv_grid_utils.F90
+++ b/model/fv_grid_utils.F90
@@ -215,18 +215,6 @@
       cos_sg(:,:,:) =  big_number
       sin_sg(:,:,:) = tiny_number
 
-      sw_corner = .false.
-      se_corner = .false.
-      ne_corner = .false.
-      nw_corner = .false.
-
-      if (grid_type < 3 .and. .not. Atm%gridstruct%bounded_domain) then
-         if (       is==1 .and.  js==1 )      sw_corner = .true.
-         if ( (ie+1)==npx .and.  js==1 )      se_corner = .true.
-         if ( (ie+1)==npx .and. (je+1)==npy ) ne_corner = .true.
-         if (       is==1 .and. (je+1)==npy ) nw_corner = .true.
-      endif
-
   if ( sw_corner ) then
        tmp1 = great_circle_dist(grid(1,1,1:2), agrid(1,1,1:2))
        tmp2 = great_circle_dist(grid(1,1,1:2), agrid(2,2,1:2))

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -565,6 +565,18 @@ contains
     latlon = .false.
     cubed_sphere = .false.
 
+    ! set corner flags
+    sw_corner = .false. 
+    se_corner = .false. 
+    ne_corner = .false. 
+    nw_corner = .false. 
+    if (Atm%flagstruct%grid_type < 3 .and. .not. Atm%gridstruct%bounded_domain) then 
+       if (       is==1 .and.  js==1 )      sw_corner = .true. 
+       if ( (ie+1)==npx .and.  js==1 )      se_corner = .true. 
+       if ( (ie+1)==npx .and. (je+1)==npy ) ne_corner = .true. 
+       if (       is==1 .and. (je+1)==npy ) nw_corner = .true. 
+    endif  
+
     if ( (Atm%flagstruct%do_schmidt .or. Atm%flagstruct%do_cube_transform) .and. abs(atm%flagstruct%stretch_fac-1.) > 1.E-5 ) then
        stretched_grid = .true.
        if (Atm%flagstruct%do_schmidt .and. Atm%flagstruct%do_cube_transform) then


### PR DESCRIPTION
This fixes issue https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/41 where of the `??_corner` flags in `init_grid()` in `tools/fv_grid_tools.F90` are being read before setting them. The initialization of `??_corner` has been moved to `tools/fv_grid_tools.F90`.

Side note to @bensonr and @lharris4: It would be great to have some regression tests integrated into GitHub in order to make sure that such PR's actually pass regression.

Thanks to @rheacangeo for the bug report!