### PR TITLE
Modify the halo extents of u and vt in the regional_boundary_update call

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -4409,6 +4409,12 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
             j1=jsd
             j2=jed
 !
+! CHJ --- s ---
+            if(trim(bc_vbl_name)=='vc'.or.trim(bc_vbl_name)=='u')then
+              j2=jed+1
+            endif
+! CHJ --- e ---
+
             i1=isd
             i2=is-1
 !
@@ -4453,7 +4459,13 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
             j1=jsd
             j2=jed
-!
+
+! CHJ --- s ---
+            if(trim(bc_vbl_name)=='vc'.or.trim(bc_vbl_name)=='u')then
+              j2=jed+1
+            endif
+! CHJ --- e ---
+
             i1=ie+1
             i2=ied
             if(trim(bc_vbl_name)=='uc'.or.trim(bc_vbl_name)=='v')then


### PR DESCRIPTION
- Modified the halo extents of 'u' and 'vt' fields in the 'regional_boundary_update' call that caused a reproducibility issue on FV3-LAM (Limited Area Model).

- Tested with two different MPI layouts (4x6) and (6x4) on Hera. In testing, the 'FV3_GFS_2017_gfdlmp_regional' CCPP suite was applied.

- The modified version has resolved the bit-difference reproducibility issue.