### PR TITLE
Merge ufs-release/public-v1 into dev/emc

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,7 +1,6 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "FV3DYCORE"
 PROJECT_LOGO	       = image/UFSLogo.png
-PROJECT_NUMBER         = "Version 1.1.0"
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES


### PR DESCRIPTION
Merging ufs-release/public-v1 into dev/emc.  Modified some of the doxygen documentation to resolve merge conflicts:

- Created a section A1.10 for Limited Area Model parameters that used to be in dev/emc branch section A.11
- Replaced section A.6 (nest_nml) from ufs-release/public-v1 branch with the contents of section A.7 (fv_nest_nml) from dev/emc branch
- Renumbered sections as appropriate