### PR TITLE
ufs-release/public-v2: merge HWRF updates, remove duplicate import of read_data from fms_mod

### DIFF
--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -774,12 +774,12 @@ contains
      if ( flagstruct%fv_debug ) then
         if (is_master()) write(*,'(A, I3, A1, I3)') 'finished k_split ', n_map, '/', k_split
        call prt_mxm('T_dyn_a3',    pt, is, ie, js, je, ng, npz, 1., gridstruct%area_64, domain)
-       call prt_mxm('SPHUM_dyn',   q(isd,jsd,1,sphum  ), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('liq_wat_dyn', q(isd,jsd,1,liq_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('rainwat_dyn', q(isd,jsd,1,rainwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('ice_wat_dyn', q(isd,jsd,1,ice_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('snowwat_dyn', q(isd,jsd,1,snowwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('graupel_dyn', q(isd,jsd,1,graupel), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if (sphum   > 0) call prt_mxm('SPHUM_dyn',   q(isd,jsd,1,sphum  ), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if (liq_wat > 0) call prt_mxm('liq_wat_dyn', q(isd,jsd,1,liq_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if (rainwat > 0) call prt_mxm('rainwat_dyn', q(isd,jsd,1,rainwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if (ice_wat > 0) call prt_mxm('ice_wat_dyn', q(isd,jsd,1,ice_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if (snowwat > 0) call prt_mxm('snowwat_dyn', q(isd,jsd,1,snowwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if (graupel > 0) call prt_mxm('graupel_dyn', q(isd,jsd,1,graupel), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
      endif
 #ifdef AVEC_TIMERS
                                                   call avec_timer_stop(6)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -148,7 +148,7 @@ module external_ic_mod
    use external_sst_mod,   only: i_sst, j_sst, sst_ncep
    use fms_mod,            only: file_exist, read_data, field_exist, write_version_number
    use fms_mod,            only: open_namelist_file, check_nml_error, close_file
-   use fms_mod,            only: get_mosaic_tile_file, read_data, error_mesg
+   use fms_mod,            only: get_mosaic_tile_file, error_mesg
    use fms_io_mod,         only: get_tile_string, field_size, free_restart_type
    use fms_io_mod,         only: restart_file_type, register_restart_field
    use fms_io_mod,         only: save_restart, restore_state, set_filename_appendix, get_global_att_value

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -570,8 +570,10 @@ contains
 
 !--- read in the number of tracers in the NCEP NGGPS ICs
       call read_data ('INPUT/'//trim(fn_gfs_ctl), 'ntrac', ntrac, no_domain=.TRUE.)
-      if (ntrac > ntracers) call mpp_error(FATAL,'==> External_ic::get_nggps_ic: more NGGPS tracers &
-                                 &than defined in field_table '//trim(fn_gfs_ctl)//' for NGGPS IC')
+      ! DH* 20200922 - this breaks Ferrier-Aligo MP runs
+      !if (ntrac > ntracers) call mpp_error(FATAL,'==> External_ic::get_nggps_ic: more NGGPS tracers &
+      !                           &than defined in field_table '//trim(fn_gfs_ctl)//' for NGGPS IC')
+      ! *DH 20200922
 
 !
       call get_data_source(source,Atm%flagstruct%regional)


### PR DESCRIPTION
This PR merges three small changes from a recent PR to dev/eemc into release/public-v2. One of them is for debugging, another for initializing model runs with less tracers than the physics requires, and yet another to remove a duplicate use statement (see issue https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/issues/45).

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/518
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/61
https://github.com/NOAA-EMC/fv3atm/pull/197
https://github.com/ufs-community/ufs-weather-model/pull/276

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/276.
