### PR TITLE
ufs-release/public-v2: initialized cld_amt to zero for regional runs

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -3701,7 +3701,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! If the source is from old GFS or operational GSM then the tracers will be fixed in the boundaries
 ! and may not provide a very good result
 ! 
-!  if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
+  if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
   if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE') then
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz


### PR DESCRIPTION
## Description

This PR contains a one-liner change in `model/fv_regional_bc.F90` to initialize `cld_amt` to zero so that regional runs using GFDL microphysics can be initialized from input data that doesn't contain `cld_amt` (e.g. RAP/HRRR input data).

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/313

## Dependencies

https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/62
https://github.com/NOAA-EMC/fv3atm/pull/207
https://github.com/ufs-community/ufs-weather-model/pull/313