### PR TITLE
ufs-release/public-v2: bit-for-bit reproducibility for regional runs when changing MPI decomposition

### DIFF
--- a/model/fv_tracer2d.F90
+++ b/model/fv_tracer2d.F90
@@ -749,6 +749,9 @@ subroutine tracer_2d_nested(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, np
                                                reg_bc_update_time,      &
                                                iq )
             enddo
+            call timing_on('COMM_TOTAL')
+            call mpp_update_domains(q, domain, complete=.true.)
+            call timing_off('COMM_TOTAL')
       endif
 
 

--- a/model/sw_core.F90
+++ b/model/sw_core.F90
@@ -118,12 +118,12 @@
       type(fv_flags_type), intent(IN), target :: flagstruct
 
 ! Local:
-      logical:: sw_corner, se_corner, ne_corner, nw_corner 
+      logical:: sw_corner, se_corner, ne_corner, nw_corner
       real, dimension(bd%is-1:bd%ie+1,bd%js-1:bd%je+1):: vort, ke
       real, dimension(bd%is-1:bd%ie+2,bd%js-1:bd%je+1):: fx, fx1, fx2
       real, dimension(bd%is-1:bd%ie+1,bd%js-1:bd%je+2):: fy, fy1, fy2
       real :: dt4
-      integer :: i,j, is2, ie1
+      integer :: i,j
       integer iep1, jep1
 
       integer :: is,  ie,  js,  je
@@ -2878,7 +2878,7 @@ end subroutine ytp_v
   utmp(:,:) = big_number
   vtmp(:,:) = big_number 
 
- if ( bounded_domain ) then  
+ if ( bounded_domain ) then
 
      do j=jsd+1,jed-1
         do i=isd,ied


### PR DESCRIPTION
This PR fixes b4b mismatches when changing the MPI decomposition for regional runs (see https://github.com/ufs-community/ufs-weather-model/pull/409 and https://github.com/ufs-community/ufs-weather-model/issues/288) for more details.

- add missing call to `mpp_update_domain` for `q` in `model/fv_tracer2d.F90`
- add missing calls and update existing calls to update domain and halos, fix compiler warnings about additional text after `#endif` statements in `model/dyn_core.F90`
- remove two unused variables from `model/sw_core.F90`
- fix a few trailing whitespaces

**Note 1.** Each of the added/modified calls to update the domain or halos is required. After achieving b4b identical results, I removed each of the changes shown here and left the rest, and every time the results were no longer b4b.

**Note 2.** The perhaps most confusing change is to move the call to `call start_group_halo_update(i_pack(8), u, v, domain, gridtype=DGRID_NE)` to further down in the code in `model/sw_core.F90`, because there is a call to a regional boundary update for `u` and `v` after the original location.

**Note 3.** I am not an expert in the FV3 dycore, and it is possible that there are alternative and easier ways to achieve the same.

Associated PRs:

https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/68
https://github.com/NOAA-EMC/fv3atm/pull/245
https://github.com/ufs-community/ufs-weather-model/pull/409

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/409.