### PR TITLE
Feb 2021: add dz_min as namelist variable and add an option to use zero-gradient BC to reconstruct interface u/v with PSM

### DIFF
--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -621,7 +621,7 @@ contains
                                             call timing_on('UPDATE_DZ_C')
          call update_dz_c(is, ie, js, je, npz, ng, dt2, dp_ref, zs, gridstruct%area, ut, vt, gz, ws3, &
              npx, npy, gridstruct%sw_corner, gridstruct%se_corner, &
-             gridstruct%ne_corner, gridstruct%nw_corner, bd, gridstruct%grid_type)
+             gridstruct%ne_corner, gridstruct%nw_corner, bd, gridstruct%grid_type, flagstruct%dz_min)
                                             call timing_off('UPDATE_DZ_C')
 
                                                call timing_on('Riem_Solver')
@@ -1029,7 +1029,8 @@ contains
 #ifndef SW_DYNAMICS
                                             call timing_on('UPDATE_DZ')
         call update_dz_d(nord_v, damp_vt, flagstruct%hord_tm, is, ie, js, je, npz, ng, npx, npy, gridstruct%area,  &
-                         gridstruct%rarea, dp_ref, zs, zh, crx, cry, xfx, yfx, ws, rdt, gridstruct, bd, flagstruct%lim_fac)    
+                         gridstruct%rarea, dp_ref, zs, zh, crx, cry, xfx, yfx, ws, rdt, gridstruct, bd, flagstruct%lim_fac, &
+                         flagstruct%dz_min, flagstruct%psm_bc)    
                                                                   call timing_off('UPDATE_DZ')
     if ( flagstruct%fv_debug ) then
          if ( .not. flagstruct%hydrostatic )    &

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -991,6 +991,13 @@ module fv_arrays_mod
                                            !< at the center of the domain (the center of tile 1), if set to .true.
                                            !< The default value is .false.
 
+   real :: dz_min = 2        !< Minimum thickness depth to  to enforce monotonicity of height to prevent blowup.
+                             !< 2 by default
+
+   integer :: psm_bc = 0     !< Option to use origional BCs (0) or zero-gradient BCs (1) 
+                             !< to reconstruct interface u/v with the Parabolic Spline Method
+                             !< for the advection of height. 0 by default. 
+
    integer :: a2b_ord = 4   !< Order of interpolation used by the pressure gradient force
                             !< to interpolate cell-centered (A-grid) values to the grid corners. 
                             !< The default value is 4 (recommended), which uses fourth-order 

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -370,6 +370,8 @@ module fv_control_mod
      logical , pointer :: nudge_qv
      real,     pointer :: add_noise
      logical , pointer :: butterfly_effect
+     real ,    pointer :: dz_min
+     integer , pointer :: psm_bc
 
      integer , pointer :: a2b_ord 
      integer , pointer :: c2l_ord 
@@ -908,6 +910,8 @@ module fv_control_mod
        nudge_qv                      => Atm%flagstruct%nudge_qv
        add_noise                     => Atm%flagstruct%add_noise
        butterfly_effect              => Atm%flagstruct%butterfly_effect
+       dz_min                        => Atm%flagstruct%dz_min
+       psm_bc                        => Atm%flagstruct%psm_bc
        a2b_ord                       => Atm%flagstruct%a2b_ord
        c2l_ord                       => Atm%flagstruct%c2l_ord
        ndims                         => Atm%flagstruct%ndims
@@ -1046,6 +1050,10 @@ module fv_control_mod
 !> \param[in] add\_noise] Real: amplitude of random thermal noise (in K) to add upon startup. Useful for perturbing initial conditions. -1 by default; disabled if 0 or negative. 
 !!
 !> \param[in] butterfly\_effect Logical: whether to flip the least-significant-bit of the lowest level temperature. False by default. 
+!!
+!> \param[in] dz\_min  Real: Minimum layer thickness to enforce monotonicity of height to prevent blowup. Set to 2 by default. 
+!!
+!> \param[in] psm\_bc  Integer: Options to use origional BCs (0) or zero-gradient BCs (1) to reconstruct interface u/v for the advection of height. Set to 0 by default. 
 !!
 !> \param[in] adjust\_dry\_mass Logical: whether to adjust the global dry-air mass to the value set by dry\_mass. This is only done in an initialization step, particularly when using an initial condition from an external dataset, interpolated from another resolution (either horizontal or vertical), or when changing the topography, so that the global mass of the atmosphere matches some estimate of observed value. False by default. It is recommended to only set this to True when initializing the model. 
 !!
@@ -1438,7 +1446,7 @@ module fv_control_mod
             c2l_ord, dx_const, dy_const, umax, deglat,      &
             deglon_start, deglon_stop, deglat_start, deglat_stop, &
             phys_hydrostatic, use_hydro_pressure, make_hybrid_z, old_divg_damp, add_noise, butterfly_effect, &
-            nested, twowaynest, nudge_qv, &
+            dz_min, psm_bc, nested, twowaynest, nudge_qv, &
             nestbctype, nestupdate, nsponge, s_weight, &
             check_negative, nudge_ic, halo_update_type, gfs_phil, agrid_vel_rst,     &
             do_uni_zfull, adj_mass_vmr, fac_n_spl, fhouri, update_blend, regional, bc_update_interval,  &

--- a/model/nh_utils.F90
+++ b/model/nh_utils.F90
@@ -66,18 +66,17 @@ module nh_utils_mod
    public sim3p0_solver, rim_2d
    public Riem_Solver_c
 
-   real, parameter:: dz_min = 6.
    real, parameter:: r3 = 1./3.
 
 CONTAINS 
 
   subroutine update_dz_c(is, ie, js, je, km, ng, dt, dp0, zs, area, ut, vt, gz, ws, &
-       npx, npy, sw_corner, se_corner, ne_corner, nw_corner, bd, grid_type)
+       npx, npy, sw_corner, se_corner, ne_corner, nw_corner, bd, grid_type, dz_min)
 ! !INPUT PARAMETERS:
   type(fv_grid_bounds_type), intent(IN) :: bd
   integer, intent(in):: is, ie, js, je, ng, km, npx, npy, grid_type
   logical, intent(IN):: sw_corner, se_corner, ne_corner, nw_corner
-  real, intent(in):: dt
+  real, intent(in):: dt, dz_min
   real, intent(in):: dp0(km)
   real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: ut, vt
   real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng):: area
@@ -196,11 +195,11 @@ CONTAINS
 6000 continue
 
 ! Enforce monotonicity of height to prevent blowup
-!$OMP parallel do default(none) shared(is1,ie1,js1,je1,ws,zs,gz,rdt,km)
+!$OMP parallel do default(none) shared(is1,ie1,js1,je1,ws,zs,gz,rdt,km,dz_min)
   do j=js1, je1
-     do k=2, km+1
+     do k=km, 1, -1 
         do i=is1, ie1
-           gz(i,j,k) = min( gz(i,j,k), gz(i,j,k-1) - dz_min )
+           gz(i,j,k) = max( gz(i,j,k), gz(i,j,k+1) + dz_min )
         enddo
      enddo
      do i=is1, ie1
@@ -212,12 +211,12 @@ CONTAINS
 
 
   subroutine update_dz_d(ndif, damp, hord, is, ie, js, je, km, ng, npx, npy, area, rarea,   &
-                         dp0, zs, zh, crx, cry, xfx, yfx, ws, rdt, gridstruct, bd, lim_fac)
+                         dp0, zs, zh, crx, cry, xfx, yfx, ws, rdt, gridstruct, bd, lim_fac, dz_min, psm_bc)
 
   type(fv_grid_bounds_type), intent(IN) :: bd
   integer, intent(in):: is, ie, js, je, ng, km, npx, npy
-  integer, intent(in):: hord
-  real, intent(in)   :: rdt
+  integer, intent(in):: hord, psm_bc
+  real, intent(in)   :: rdt, dz_min
   real, intent(in)   :: dp0(km)
   real, intent(in)   :: area(is-ng:ie+ng,js-ng:je+ng)
   real, intent(in)   :: rarea(is-ng:ie+ng,js-ng:je+ng)
@@ -253,15 +252,27 @@ CONTAINS
   isd = is - ng;  ied = ie + ng
   jsd = js - ng;  jed = je + ng
 
-!$OMP parallel do default(none) shared(jsd,jed,crx,xfx,crx_adv,xfx_adv,is,ie,isd,ied, &
-!$OMP                                  km,dp0,uniform_grid,js,je,cry,yfx,cry_adv,yfx_adv)
-  do j=jsd,jed
-     call edge_profile(crx, xfx, crx_adv, xfx_adv, is,  ie+1, jsd, jed, j, km, &
+  if (psm_bc == 0 )then
+!$OMP parallel do default(none) shared(jsd,jed,crx,xfx,crx_adv,xfx_adv,is,ie,isd,ied,     &
+!$OMP                                  km,dp0,uniform_grid,js,je,cry,yfx,cry_adv,yfx_adv) 
+      do j=jsd,jed
+           call edge_profile(crx, xfx, crx_adv, xfx_adv, is,  ie+1, jsd, jed, j, km, &
                             dp0, uniform_grid, 0)
-     if ( j<=je+1 .and. j>=js )      &
-     call edge_profile(cry, yfx, cry_adv, yfx_adv, isd, ied,  js, je+1, j, km, &
+           if ( j<=je+1 .and. j>=js )      &
+           call edge_profile(cry, yfx, cry_adv, yfx_adv, isd, ied,  js, je+1, j, km, &
                             dp0, uniform_grid, 0)
-  enddo
+      enddo
+  else
+!$OMP parallel do default(none) shared(jsd,jed,crx,xfx,crx_adv,xfx_adv,is,ie,isd,ied,     &
+!$OMP                                  km,dp0,uniform_grid,js,je,cry,yfx,cry_adv,yfx_adv) 
+      do j=jsd,jed
+           call edge_profile_0grad(crx, xfx, crx_adv, xfx_adv, is,  ie+1, jsd, jed, j, km, &
+                            dp0, uniform_grid, 0)
+           if ( j<=je+1 .and. j>=js )      &
+           call edge_profile_0grad(cry, yfx, cry_adv, yfx_adv, isd, ied,  js, je+1, j, km, &
+                            dp0, uniform_grid, 0)
+      enddo
+  endif
 
 !$OMP parallel do default(none) shared(is,ie,js,je,isd,ied,jsd,jed,km,area,xfx_adv,yfx_adv, &
 !$OMP                                  damp,zh,crx_adv,cry_adv,npx,npy,hord,gridstruct,bd,  &
@@ -310,12 +321,12 @@ CONTAINS
 
   enddo
 
-!$OMP parallel do default(none) shared(is,ie,js,je,km,ws,zs,zh,rdt)
+!$OMP parallel do default(none) shared(is,ie,js,je,km,ws,zs,zh,rdt,dz_min)
   do j=js, je
-     do k=2, km+1
+     do k=km, 1, -1
         do i=is, ie
 ! Enforce monotonicity of height to prevent blowup
-           zh(i,j,k) = min( zh(i,j,k), zh(i,j,k-1) - dz_min )
+           zh(i,j,k) = max( zh(i,j,k), zh(i,j,k+1) + dz_min )
         enddo
      enddo
      do i=is,ie
@@ -1892,6 +1903,118 @@ CONTAINS
     enddo
 
  end subroutine edge_profile
+
+ subroutine edge_profile_0grad(q1, q2, q1e, q2e, i1, i2, j1, j2, j, km, dp0, uniform_grid, limiter)
+! Optimized for wind profile reconstruction:
+! Added this option by Henry Juang and Xiaqiong Zhou 1/21/2021
+ integer, intent(in):: i1, i2, j1, j2
+ integer, intent(in):: j, km
+ integer, intent(in):: limiter
+ logical, intent(in):: uniform_grid
+ real, intent(in):: dp0(km)
+ real, intent(in),  dimension(i1:i2,j1:j2,km):: q1, q2
+ real, intent(out), dimension(i1:i2,j1:j2,km+1):: q1e, q2e
+!-----------------------------------------------------------------------
+ real, dimension(i1:i2,km+1):: qe1, qe2, gam  ! edge values
+ real  gak(km)
+ real  bet, r2o3, r4o3
+ real  g0, gk, xt1, xt2, a_bot
+ integer i, k
+
+ if ( uniform_grid ) then
+!------------------------------------------------
+! Optimized coding for uniform grid: SJL Apr 2007
+!------------------------------------------------
+     r2o3 = 2./3.
+     r4o3 = 4./3.
+     do i=i1,i2
+        qe1(i,1) = r4o3*q1(i,j,1) + r2o3*q1(i,j,2)
+        qe2(i,1) = r4o3*q2(i,j,1) + r2o3*q2(i,j,2)
+     enddo
+
+        gak(1) = 7./3.
+     do k=2,km
+        gak(k) =  1. / (4. - gak(k-1))
+        do i=i1,i2
+           qe1(i,k) = (3.*(q1(i,j,k-1) + q1(i,j,k)) - qe1(i,k-1)) * gak(k)
+           qe2(i,k) = (3.*(q2(i,j,k-1) + q2(i,j,k)) - qe2(i,k-1)) * gak(k)
+        enddo
+     enddo
+
+     bet = 1. / (1.5 - 3.5*gak(km))
+     do i=i1,i2
+        qe1(i,km+1) = (4.*q1(i,j,km) + q1(i,j,km-1) - 3.5*qe1(i,km)) * bet
+        qe2(i,km+1) = (4.*q2(i,j,km) + q2(i,j,km-1) - 3.5*qe2(i,km)) * bet
+     enddo
+
+     do k=km,1,-1
+        do i=i1,i2
+           qe1(i,k) = qe1(i,k) - gak(k)*qe1(i,k+1)
+           qe2(i,k) = qe2(i,k) - gak(k)*qe2(i,k+1)
+        enddo
+     enddo
+ else
+! Assuming grid varying in vertical only
+   g0 = dp0(1) / dp0(2)
+   bet = 1.5 + 2.*g0
+   do i=i1,i2
+      qe1(i,2) = 3.*( 0.5*q1(i,j,1) + g0*q1(i,j,2) ) / bet
+      qe2(i,2) = 3.*( 0.5*q2(i,j,1) + g0*q2(i,j,2) ) / bet
+      gam(i,1) =  g0/bet
+   enddo
+
+
+! for k=2,km
+  do k=2,km-1
+        gk = dp0(k) / dp0(k+1)
+     do i=i1,i2
+        bet =  2. + 2.*gk - gam(i,k-1)
+        qe1(i,k+1) = ( 3.*(q1(i,j,k)+gk*q1(i,j,k+1)) - qe1(i,k) ) / bet
+        qe2(i,k+1) = ( 3.*(q2(i,j,k)+gk*q2(i,j,k+1)) - qe2(i,k) ) / bet
+        gam(i,k) = gk / bet
+     enddo
+  enddo
+
+!km+1
+  do i=i1,i2
+     bet = 2.- gam(i,km-1)
+     qe1(i,km+1) = ( 3.*q1(i,j,km) - qe1(i,km) ) / bet
+     qe2(i,km+1) = ( 3.*q2(i,j,km) - qe2(i,km) ) / bet
+  enddo
+
+  do i=i1,i2
+     do k=km,2,-1
+        qe1(i,k) = qe1(i,k) - gam(i,k-1)*qe1(i,k+1)
+        qe2(i,k) = qe2(i,k) - gam(i,k-1)*qe2(i,k+1)
+     enddo
+     qe1(i,1)=1.5*q1(i,j,1)-0.5*qe1(i,2)
+     qe2(i,1)=1.5*q2(i,j,1)-0.5*qe2(i,2)
+  enddo
+
+ endif
+
+!------------------
+! Apply constraints
+!------------------
+    if ( limiter/=0 ) then   ! limit the top & bottom winds
+         do i=i1,i2
+! Top
+            if ( q1(i,j,1)*qe1(i,1) < 0. ) qe1(i,1) = 0.
+            if ( q2(i,j,1)*qe2(i,1) < 0. ) qe2(i,1) = 0.
+! Surface:
+            if ( q1(i,j,km)*qe1(i,km+1) < 0. ) qe1(i,km+1) = 0.
+            if ( q2(i,j,km)*qe2(i,km+1) < 0. ) qe2(i,km+1) = 0.
+         enddo
+    endif
+
+    do k=1,km+1
+       do i=i1,i2
+          q1e(i,j,k) = qe1(i,k)
+          q2e(i,j,k) = qe2(i,k)
+       enddo
+    enddo
+
+ end subroutine edge_profile_0grad
 
 !TODO LMH 25may18: do not need delz defined on full compute domain; pass appropriate BCs instead
  subroutine nh_bc(ptop, grav, kappa, cp, delp, delzBC, pt, phis, &


### PR DESCRIPTION
There is one commit ([PR#53](https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/53)) from EMC fork:

* 1)Add an option to use original BC or zero-gradient BC to reconstruct interface u/v with PSM for height advection
2)Change dz_min as a namelist input
* Change to the original version by adjust the upper interface of ZH when dz<dz_min
* add authors for the revision