### PR TITLE
remove Fortran 2018 compliance warnings when compiling with gcc 20

### DIFF
--- a/GFDL_tools/fv_ada_nudge.F90
+++ b/GFDL_tools/fv_ada_nudge.F90
@@ -1034,7 +1034,8 @@ endif
            pt0 = tm(i,j)/(pk0(km+1)-pk0(km))*(kappa*(pn0(km+1)-pn0(km)))
            pst = pk0(km+1) + (gz0(i,j)-phis(i,j))/(cp_air*pt0)
       endif
-666   ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+      ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+666   continue ! i-loop
       enddo   ! j-loop
 
       if( nf_ps>0 ) call del2_scalar(ps_dt, del2_cd, 1, nf_ps, bd, npx, npy, gridstruct, domain)

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -5051,17 +5051,21 @@ contains
 
       km1 = km - 1
 
-      do 500 k=2,km
-      do 500 i=1,im
-500   a6(i,k) = delp(i,k-1) + delp(i,k)
+      do k=2,km
+      do i=1,im
+      a6(i,k) = delp(i,k-1) + delp(i,k)
+      enddo
+      enddo
 
-      do 1000 k=1,km1
-      do 1000 i=1,im
+
+      do k=1,km1
+      do i=1,im
       delq(i,k) = p(i,k+1) - p(i,k)
-1000  continue
+      enddo
+      enddo
 
-      do 1220 k=2,km1
-      do 1220 i=1,im
+      do k=2,km1
+      do i=1,im
       c1 = (delp(i,k-1)+0.5*delp(i,k))/a6(i,k+1)
       c2 = (delp(i,k+1)+0.5*delp(i,k))/a6(i,k)
       tmp = delp(i,k)*(c1*delq(i,k) + c2*delq(i,k-1)) /    &
@@ -5069,7 +5073,8 @@ contains
       qmax = max(p(i,k-1),p(i,k),p(i,k+1)) - p(i,k)
       qmin = p(i,k) - min(p(i,k-1),p(i,k),p(i,k+1))
       dc(i,k) = sign(min(abs(tmp),qmax,qmin), tmp)
-1220  continue
+      enddo
+      enddo
 
 !****6***0*********0*********0*********0*********0*********0**********72
 ! 4th order interpolation of the provisional cell edge value

--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -801,8 +801,9 @@ module fv_nwp_nudge_mod
            pt0 = tm(i,j)/(pk0(km+1)-pk0(km))*(kappa*(pn0(km+1)-pn0(km)))
            pst = pk0(km+1) + (gz0(i,j)-phis(i,j))/(cp_air*pt0)
       endif
-666   ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
-      enddo   ! j-loop
+       ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+666    continue ! i-loop 
+    enddo   ! j-loop
 
       if( nf_ps>0 ) call del2_scalar(ps_dt, del2_cd, 1, nf_ps, bd, npx, npy, gridstruct, domain)
 


### PR DESCRIPTION
resolves #78 on dev/gfdl