### PR TITLE
fixes missing argument in store_data for case where GFS_PHYS macro no…

### DIFF
--- a/tools/fv_nggps_diag.F90
+++ b/tools/fv_nggps_diag.F90
@@ -584,7 +584,7 @@ contains
     endif
 #else
     !--- DELP
-    if(id_delp > 0) call store_data(id_delp, Atm(n)%delp(isco:ieco,jsco:jeco,:), Time, kstt_delp)
+    if(id_delp > 0) call store_data(id_delp, Atm(n)%delp(isco:ieco,jsco:jeco,:), Time, kstt_delp, kend_delp)
 
     !--- Surface Pressure (PS)
     if( id_ps > 0) then


### PR DESCRIPTION
Missing argument to store_data for the delp diagnostic when GFS_PHYS macro not enabled

Fixes # (issue) 
no issue created

**How Has This Been Tested?**

This has been tested as part of he compile for the merge of master -> dev/gfdl

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
