### PR TITLE
add in test for do_cube_transform in fv_grid_tool::init_grid

### DIFF
--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -666,7 +666,7 @@ contains
                            Atm%flagstruct%target_lon, Atm%flagstruct%target_lat, &
                            n, grid_global(1:npx,1:npy,1,n), grid_global(1:npx,1:npy,2,n))
                    enddo
-                else
+                elseif ( Atm%flagstruct%do_cube_transform) then
                    do n=1,nregions
                       call cube_transform(Atm%flagstruct%stretch_fac, 1, npx, 1, npy, &
                            Atm%flagstruct%target_lon, Atm%flagstruct%target_lat, &


### PR DESCRIPTION
**Description**

Re-introduces a fix from dev/gfdl that should be in master.  This update changes an else to an elseif conditional around a call to cube_transform in fv_grid_tools::init_grid.  This function is an option for generating a stretched grid internally.  Without this conditional, all internally generated grids run through this function and will not match a grid generated externally.

Fixes # (issue) - no issue created

**How Has This Been Tested?**

This has been tested as part of the merge of master -> dev/gfdl.  

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
