### PR TITLE
fixes bug in regional bc time calculation in fv_tracer2d.F90

### DIFF
--- a/model/fv_tracer2d.F90
+++ b/model/fv_tracer2d.F90
@@ -715,7 +715,7 @@ subroutine tracer_2d_nested(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, np
       if (gridstruct%regional) then
             !This is more accurate than the nested BC calculation
             ! since it takes into account varying nsplit
-            reg_bc_update_time=current_time_in_seconds+(real(n_map-1) + real(it-1)/frac)*dt
+            reg_bc_update_time=current_time_in_seconds+(real(n_map-1) + real(it-1)*frac)*dt
             do iq=1,nq
                  call regional_boundary_update(q(:,:,:,iq), 'q', &
                                                isd, ied, jsd, jed, npz, &


### PR DESCRIPTION
**Description**

Fixes a bug identified during the merge into dev/emc.  The bug affects the time trigger for the regional bc updates.

Fixes # (issue)

**How Has This Been Tested?**

Tested via dev/emc merge.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
