### PR TITLE
Add 'netcdf' and 'grib2' to input 'source' options in regional IC/LBC routines

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -248,7 +248,7 @@ module fv_regional_mod
 
       integer :: a_step, p_step, k_step, n_step
 !
-      integer :: src_grp   ! source group
+      integer :: data_source_group
 contains
 
 !-----------------------------------------------------------------------
@@ -1254,7 +1254,7 @@ contains
 !***  Get the source of the input data
 !-----------------------------------------------------------------------
 !
-      call get_data_source(src_grp,Atm%flagstruct%regional)
+      call get_data_source(data_source_group,Atm%flagstruct%regional)
 !
       call setup_regional_BC(Atm, dt_atmos                              &
                             ,isd, ied, jsd, jed                         &
@@ -1367,7 +1367,7 @@ contains
 !***  Get the source of the input data.
 !-----------------------------------------------------------------------
 !
-      call get_data_source(src_grp,Atm%flagstruct%regional)
+      call get_data_source(data_source_group,Atm%flagstruct%regional)
 !
 !-----------------------------------------------------------------------
 !***  Preliminary setup for the forecast.
@@ -1723,7 +1723,7 @@ contains
 !***  Sensible temperature
 !--------------------------
 !
-      if ( src_grp==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
+      if ( data_source_group==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
         nlev=klev_in
         var_name_root='t'
         call read_regional_bc_file(is_input,ie_input,js_input,je_input  &
@@ -3676,7 +3676,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
 ! Compute true temperature using hydrostatic balance if not read from input.
 
-        if ( src_grp/=1 ) then ! NOT GFS NEMSIO/NETCDF/GRIB2
+        if ( data_source_group/=1 ) then ! NOT GFS NEMSIO/NETCDF/GRIB2
           do k=1,npz
             BC_side%pt_BC(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*(1.+zvir*BC_side%q_BC(i,j,k,sphum)) )
           enddo
@@ -3702,7 +3702,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! and may not provide a very good result
 !
   if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
-  if ( src_grp/=1 ) then  ! NOT GFS NEMSIO/NETCDF/GRIB2
+  if ( data_source_group/=1 ) then  ! NOT GFS NEMSIO/NETCDF/GRIB2
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz
          do i=is,ie
@@ -3762,7 +3762,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
 
-      if ( src_grp==1 ) then
+      if ( data_source_group==1 ) then
         do k=1,npz
           do i=is,ie
             BC_side%w_BC(i,j,k) = qn1(i,k)
@@ -6632,12 +6632,12 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 !---------------------------------------------------------------------
 
-  subroutine get_data_source(src_grp,regional)
+  subroutine get_data_source(data_source_group,regional)
 !
 ! This routine extracts the data source information if it is present in the datafile.
 !
       character (len = 80) :: source      
-      integer :: src_grp   ! source group
+      integer :: data_source_group
       logical :: lstatus,regional
 !
 ! Use the fms call here so we can actually get the return code value.
@@ -6661,8 +6661,8 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
       if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
            trim(source)=='FV3GFS GAUSSIAN NETCDF FILE' .or.        &
            trim(source)=='FV3GFS GRIB2 FILE'                ) then
-         src_grp = 1
-         if (mpp_pe()==0) write(*,*) 'IC source group=',src_grp
+         data_source_group = 1
+         if (mpp_pe()==0) write(*,*) 'IC data source group=',data_source_group
       endif
 
   end subroutine get_data_source
@@ -6697,7 +6697,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
    graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
    cld_amt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
 !
-   source: if ( src_grp==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
+   source: if ( data_source_group==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
 !
 !    if (cld_amt > 0) BC_side%q_BC(:,:,:,cld_amt) = 0.0    ! Moorthi
      do k=1,npz

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -1723,7 +1723,8 @@ contains
 !***  Sensible temperature
 !--------------------------
 !
-      if (data_source == 'FV3GFS GAUSSIAN NEMSIO FILE') then
+      if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.             & 
+          trim(data_source) == 'FV3GFS GAUSSIAN NETCDF FILE'    ) then
         nlev=klev_in
         var_name_root='t'
         call read_regional_bc_file(is_input,ie_input,js_input,je_input  &
@@ -3676,7 +3677,8 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
 ! Compute true temperature using hydrostatic balance if not read from input.
 
-        if (data_source /= 'FV3GFS GAUSSIAN NEMSIO FILE') then
+        if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and.          &
+            trim(data_source) /= 'FV3GFS GAUSSIAN NETCDF FILE'       ) then
           do k=1,npz
             BC_side%pt_BC(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*(1.+zvir*BC_side%q_BC(i,j,k,sphum)) )
           enddo
@@ -3696,13 +3698,14 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! From Jan-Huey Chen's HiRAM code
 !-----------------------------------------------------------------------
 !
-! If the source is FV3GFS GAUSSIAN NEMSIO FILE then all the tracers are in the boundary files
+! If the source is FV3GFS GAUSSIAN NEMSIO/NETCDF FILE then all the tracers are in the boundary files
 ! and will be read in.
 ! If the source is from old GFS or operational GSM then the tracers will be fixed in the boundaries
 ! and may not provide a very good result
 !
   if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
-  if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE') then
+  if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and.        &
+      trim(data_source) /= 'FV3GFS GAUSSIAN NETCDF FILE'       ) then
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz
          do i=is,ie
@@ -3745,7 +3748,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
          enddo
       enddo
    endif
-  endif ! data source /= FV3GFS GAUSSIAN NEMSIO FILE
+  endif ! data source /= FV3GFS GAUSSIAN NEMSIO/NETCDF FILE
 !
 ! For GFS spectral input, omega in pa/sec is stored as w in the input data so actual w(m/s) is calculated
 ! For GFS nemsio input, omega is 0, so best not to use for input since boundary data will not exist for w
@@ -3762,7 +3765,8 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
 
-      if (data_source == 'FV3GFS GAUSSIAN NEMSIO FILE') then
+      if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
+          trim(data_source) == 'FV3GFS GAUSSIAN NETCDF FILE'      ) then
         do k=1,npz
           do i=is,ie
             BC_side%w_BC(i,j,k) = qn1(i,k)
@@ -3785,7 +3789,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
           enddo
         enddo
 
-      else          !<-- datasource /= 'FV3GFS GAUSSIAN NEMSIO FILE'
+      else          !<-- datasource /= 'FV3GFS GAUSSIAN NEMSIO/NETCDF FILE'
         do k=1,npz
           do i=is,ie
             BC_side%w_BC(i,j,k) = qn1(i,k)/BC_side%delp_BC(i,j,k)*BC_side%delz_BC(i,j,k)
@@ -6683,7 +6687,8 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
    graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
    cld_amt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
 !
-   source: if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE') then
+   source: if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
+               trim(data_source) == 'FV3GFS GAUSSIAN NETCDF FILE'      ) then
 !
 !    if (cld_amt > 0) BC_side%q_BC(:,:,:,cld_amt) = 0.0    ! Moorthi
      do k=1,npz

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -6654,7 +6654,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
        source='No Source Attribute'
       endif
 
-! data source string to global string --------
+! Logical flag for fv3gfs nemsio/netcdf/grib2 --------
       if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
            trim(source)=='FV3GFS GAUSSIAN NETCDF FILE' .or.        &
            trim(source)=='FV3GFS GRIB2 FILE'                ) then

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -6636,9 +6636,11 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
 ! This routine extracts the data source information if it is present in the datafile.
 !
+      logical, intent(in):: regional
+      logical, intent(out):: data_source_fv3gfs
+
       character (len=80) :: source      
-      logical :: lstatus,regional
-      logical :: data_source_fv3gfs
+      logical :: lstatus
 !
 ! Use the fms call here so we can actually get the return code value.
 ! The term 'source' is specified by 'chgres_cube'
@@ -6648,11 +6650,11 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
       else
        lstatus = get_global_att_value('INPUT/gfs_data.tile1.nc',"source", source)
       endif
-      if (mpp_pe()==0) write(*,*) 'INPUT gfs_data source string=',source
       if (.not. lstatus) then
        if (mpp_pe() == 0) write(0,*) 'INPUT source not found ',lstatus,' set source=No Source Attribute'
        source='No Source Attribute'
       endif
+      if (mpp_pe()==0) write(*,*) 'INPUT gfs_data source string=',source
 
 ! Logical flag for fv3gfs nemsio/netcdf/grib2 --------
       if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -248,7 +248,7 @@ module fv_regional_mod
 
       integer :: a_step, p_step, k_step, n_step
 !
-      character(len=80) :: data_source
+      integer :: src_grp   ! source group
 contains
 
 !-----------------------------------------------------------------------
@@ -1254,7 +1254,7 @@ contains
 !***  Get the source of the input data
 !-----------------------------------------------------------------------
 !
-      call get_data_source(data_source,Atm%flagstruct%regional)
+      call get_data_source(src_grp,Atm%flagstruct%regional)
 !
       call setup_regional_BC(Atm, dt_atmos                              &
                             ,isd, ied, jsd, jed                         &
@@ -1367,7 +1367,7 @@ contains
 !***  Get the source of the input data.
 !-----------------------------------------------------------------------
 !
-      call get_data_source(data_source,Atm%flagstruct%regional)
+      call get_data_source(src_grp,Atm%flagstruct%regional)
 !
 !-----------------------------------------------------------------------
 !***  Preliminary setup for the forecast.
@@ -1723,7 +1723,7 @@ contains
 !***  Sensible temperature
 !--------------------------
 !
-      if (trim(data_source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE') then
+      if ( src_grp==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
         nlev=klev_in
         var_name_root='t'
         call read_regional_bc_file(is_input,ie_input,js_input,je_input  &
@@ -3676,7 +3676,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
 ! Compute true temperature using hydrostatic balance if not read from input.
 
-        if ( trim(data_source)/='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
+        if ( src_grp/=1 ) then ! NOT GFS NEMSIO/NETCDF/GRIB2
           do k=1,npz
             BC_side%pt_BC(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*(1.+zvir*BC_side%q_BC(i,j,k,sphum)) )
           enddo
@@ -3702,7 +3702,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! and may not provide a very good result
 !
   if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
-  if ( trim(data_source)/='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
+  if ( src_grp/=1 ) then  ! NOT GFS NEMSIO/NETCDF/GRIB2
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz
          do i=is,ie
@@ -3762,7 +3762,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
 
-      if ( trim(data_source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
+      if ( src_grp==1 ) then
         do k=1,npz
           do i=is,ie
             BC_side%w_BC(i,j,k) = qn1(i,k)
@@ -6632,15 +6632,16 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 !---------------------------------------------------------------------
 
-  subroutine get_data_source(source,regional)
+  subroutine get_data_source(src_grp,regional)
 !
 ! This routine extracts the data source information if it is present in the datafile.
 !
-      character (len = 80) :: source
-      integer              :: ncids,sourceLength
+      character (len = 80) :: source      
+      integer :: src_grp   ! source group
       logical :: lstatus,regional
 !
 ! Use the fms call here so we can actually get the return code value.
+! The term 'source' is specified by 'chgres_cube'
 !
       if (regional) then
        lstatus = get_global_att_value('INPUT/gfs_data.nc',"source", source)
@@ -6653,11 +6654,15 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
        source='No Source Attribute'
       endif
 
+! source groups --------
+! 1: GFS NEMSIO, NETCDF, GRIB2
+! 2: others
+
       if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
            trim(source)=='FV3GFS GAUSSIAN NETCDF FILE' .or.        &
            trim(source)=='FV3GFS GRIB2 FILE'                ) then
-         source = 'FV3GFS NEMSIO/NETCDF/GRIB2 FILE'
-         if (mpp_pe()==0) write(*,*) 'New IC source name=',source
+         src_grp = 1
+         if (mpp_pe()==0) write(*,*) 'IC source group=',src_grp
       endif
 
   end subroutine get_data_source
@@ -6692,7 +6697,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
    graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
    cld_amt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
 !
-   source: if ( trim(data_source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
+   source: if ( src_grp==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
 !
 !    if (cld_amt > 0) BC_side%q_BC(:,:,:,cld_amt) = 0.0    ! Moorthi
      do k=1,npz

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -6654,16 +6654,18 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
        source='No Source Attribute'
       endif
 
-! source groups --------
-! 1: GFS NEMSIO, NETCDF, GRIB2
-! 2: others
+! data source groups --------
+! 1: FV3GFS NEMSIO, NETCDF, GRIB2
+! 0: others
 
       if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
            trim(source)=='FV3GFS GAUSSIAN NETCDF FILE' .or.        &
            trim(source)=='FV3GFS GRIB2 FILE'                ) then
          data_source_group = 1
-         if (mpp_pe()==0) write(*,*) 'IC data source group=',data_source_group
+      else
+         data_source_group = 0
       endif
+      if (mpp_pe()==0) write(*,*) 'IC data source group=',data_source_group
 
   end subroutine get_data_source
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -1723,9 +1723,7 @@ contains
 !***  Sensible temperature
 !--------------------------
 !
-      if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        & 
-          trim(data_source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        &
-          trim(data_source) == 'FV3GFS GRIB2 FILE'                ) then
+      if (trim(data_source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE') then
         nlev=klev_in
         var_name_root='t'
         call read_regional_bc_file(is_input,ie_input,js_input,je_input  &
@@ -3678,9 +3676,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
 ! Compute true temperature using hydrostatic balance if not read from input.
 
-        if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and.        &
-            trim(data_source) /= 'FV3GFS GAUSSIAN NETCDF FILE' .and.        &
-            trim(data_source) /= 'FV3GFS GRIB2 FILE'                 ) then
+        if ( trim(data_source)/='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
           do k=1,npz
             BC_side%pt_BC(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*(1.+zvir*BC_side%q_BC(i,j,k,sphum)) )
           enddo
@@ -3706,9 +3702,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! and may not provide a very good result
 !
   if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
-  if (trim(data_source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and.        &
-      trim(data_source) /= 'FV3GFS GAUSSIAN NETCDF FILE' .and.        & 
-      trim(data_source) /= 'FV3GFS GRIB2 FILE'                 ) then
+  if ( trim(data_source)/='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz
          do i=is,ie
@@ -3768,9 +3762,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
 
-      if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
-          trim(data_source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        & 
-          trim(data_source) == 'FV3GFS GRIB2 FILE'                ) then
+      if ( trim(data_source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
         do k=1,npz
           do i=is,ie
             BC_side%w_BC(i,j,k) = qn1(i,k)
@@ -6660,6 +6652,14 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
        if (mpp_pe() == 0) write(0,*) 'INPUT source not found ',lstatus,' set source=No Source Attribute'
        source='No Source Attribute'
       endif
+
+      if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
+           trim(source)=='FV3GFS GAUSSIAN NETCDF FILE' .or.        &
+           trim(source)=='FV3GFS GRIB2 FILE'                ) then
+         source = 'FV3GFS NEMSIO/NETCDF/GRIB2 FILE'
+         if (mpp_pe()==0) write(*,*) 'New IC source name=',source
+      endif
+
   end subroutine get_data_source
 
 !---------------------------------------------------------------------
@@ -6692,9 +6692,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
    graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
    cld_amt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
 !
-   source: if (trim(data_source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
-               trim(data_source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        &
-               trim(data_source) == 'FV3GFS GRIB2 FILE'                ) then
+   source: if ( trim(data_source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
 !
 !    if (cld_amt > 0) BC_side%q_BC(:,:,:,cld_amt) = 0.0    ! Moorthi
      do k=1,npz

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -248,7 +248,8 @@ module fv_regional_mod
 
       integer :: a_step, p_step, k_step, n_step
 !
-      integer :: data_source_group
+      character(len=80) :: data_source
+      character(len=26), parameter:: data_source_fv3gfs='FV3GFS NEMSIO/NETCDF/GRIB2'
 contains
 
 !-----------------------------------------------------------------------
@@ -1254,7 +1255,7 @@ contains
 !***  Get the source of the input data
 !-----------------------------------------------------------------------
 !
-      call get_data_source(data_source_group,Atm%flagstruct%regional)
+      call get_data_source(data_source,Atm%flagstruct%regional)
 !
       call setup_regional_BC(Atm, dt_atmos                              &
                             ,isd, ied, jsd, jed                         &
@@ -1367,7 +1368,7 @@ contains
 !***  Get the source of the input data.
 !-----------------------------------------------------------------------
 !
-      call get_data_source(data_source_group,Atm%flagstruct%regional)
+      call get_data_source(data_source,Atm%flagstruct%regional)
 !
 !-----------------------------------------------------------------------
 !***  Preliminary setup for the forecast.
@@ -1723,7 +1724,7 @@ contains
 !***  Sensible temperature
 !--------------------------
 !
-      if ( data_source_group==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
+      if ( trim(data_source)==data_source_fv3gfs ) then
         nlev=klev_in
         var_name_root='t'
         call read_regional_bc_file(is_input,ie_input,js_input,je_input  &
@@ -3676,7 +3677,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
 ! Compute true temperature using hydrostatic balance if not read from input.
 
-        if ( data_source_group/=1 ) then ! NOT GFS NEMSIO/NETCDF/GRIB2
+        if ( trim(data_source)/=data_source_fv3gfs ) then
           do k=1,npz
             BC_side%pt_BC(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*(1.+zvir*BC_side%q_BC(i,j,k,sphum)) )
           enddo
@@ -3702,7 +3703,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 ! and may not provide a very good result
 !
   if (cld_amt .gt. 0) BC_side%q_BC(:,:,:,cld_amt) = 0.
-  if ( data_source_group/=1 ) then  ! NOT GFS NEMSIO/NETCDF/GRIB2
+  if ( trim(data_source)/=data_source_fv3gfs ) then
    if ( Atm%flagstruct%nwat .eq. 6 ) then
       do k=1,npz
          do i=is,ie
@@ -3762,7 +3763,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
 
-      if ( data_source_group==1 ) then
+      if ( trim(data_source)==data_source_fv3gfs ) then
         do k=1,npz
           do i=is,ie
             BC_side%w_BC(i,j,k) = qn1(i,k)
@@ -6632,12 +6633,11 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 !---------------------------------------------------------------------
 
-  subroutine get_data_source(data_source_group,regional)
+  subroutine get_data_source(source,regional)
 !
 ! This routine extracts the data source information if it is present in the datafile.
 !
-      character (len = 80) :: source      
-      integer :: data_source_group
+      character (len=80) :: source      
       logical :: lstatus,regional
 !
 ! Use the fms call here so we can actually get the return code value.
@@ -6648,24 +6648,19 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
       else
        lstatus = get_global_att_value('INPUT/gfs_data.tile1.nc',"source", source)
       endif
-      if (mpp_pe()==0) write(*,*) 'INPUT gfs_data source=',source
+      if (mpp_pe()==0) write(*,*) 'INPUT gfs_data source string=',source
       if (.not. lstatus) then
        if (mpp_pe() == 0) write(0,*) 'INPUT source not found ',lstatus,' set source=No Source Attribute'
        source='No Source Attribute'
       endif
 
-! data source groups --------
-! 1: FV3GFS NEMSIO, NETCDF, GRIB2
-! 0: others
-
+! data source string to global string --------
       if ( trim(source)=='FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
            trim(source)=='FV3GFS GAUSSIAN NETCDF FILE' .or.        &
            trim(source)=='FV3GFS GRIB2 FILE'                ) then
-         data_source_group = 1
-      else
-         data_source_group = 0
+         source = 'FV3GFS NEMSIO/NETCDF/GRIB2'
+         if (mpp_pe()==0) write(*,*) 'New data source string=',source
       endif
-      if (mpp_pe()==0) write(*,*) 'IC data source group=',data_source_group
 
   end subroutine get_data_source
 
@@ -6699,7 +6694,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
    graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
    cld_amt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
 !
-   source: if ( data_source_group==1 ) then  ! GFS NEMSIO/NETCDF/GRIB2
+   source: if ( trim(data_source)==data_source_fv3gfs ) then
 !
 !    if (cld_amt > 0) BC_side%q_BC(:,:,:,cld_amt) = 0.0    ! Moorthi
      do k=1,npz

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -3409,7 +3409,7 @@ contains
 ! seperate cloud water and cloud ice from Jan-Huey Chen's HiRAM code
 ! only use for NCEP IC and GFDL microphy
 !-----------------------------------------------------------------------
-   if ( .not.data_source_fv3gfs ) then
+   if ( .not. data_source_fv3gfs ) then
       if ((Atm%flagstruct%nwat .eq. 3 .or. Atm%flagstruct%nwat .eq. 6) .and. &
            (Atm%flagstruct%ncep_ic .or. Atm%flagstruct%nggps_ic)) then
          do k=1,npz

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -576,6 +576,8 @@ contains
          call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NEMSIO FILE")
       else if (trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE') then
          call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NETCDF FILE")
+      else if (trim(source) == 'FV3GFS GRIB2 FILE') then
+         call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS GRIB2 FILE")
       endif
 !
 !--- read in ak and bk from the gfs control file using fms_io read_data ---
@@ -843,8 +845,9 @@ contains
         snowwat = get_tracer_index(MODEL_ATMOS, 'snowwat')
         graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
         ntclamt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
-        if (trim(source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.       & 
-            trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE'     ) then
+        if (trim(source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        & 
+            trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        &
+            trim(source) == 'FV3GFS GRIB2 FILE'                ) then
         do k=1,npz
           do j=js,je
             do i=is,ie
@@ -863,7 +866,7 @@ contains
             enddo
           enddo
         enddo
-       else ! not NEMSIO/NETCDF
+       else ! not NEMSIO/NETCDF/GRIB2
 !--- Add cloud condensate from GFS to total MASS
 ! 20160928: Adjust the mixing ratios consistently...
            do k=1,npz
@@ -3377,8 +3380,9 @@ contains
 !----------------------------------------------------
 ! Compute true temperature using hydrostatic balance
 !----------------------------------------------------
-      if ( (trim(source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and. trim(source) /= 'FV3GFS GAUSSIAN NETCDF FILE' ) &
-            .or. .not. present(t_in)  ) then
+      if ( (trim(source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and. &  
+            trim(source) /= 'FV3GFS GAUSSIAN NETCDF FILE' .and. &
+            trim(source) /= 'FV3GFS GRIB2 FILE') .or. .not. present(t_in)  ) then
         do k=1,npz
 #ifdef MULTI_GASES
            Atm%pt(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*virq(Atm%q(i,j,k,:)) )
@@ -3414,7 +3418,8 @@ contains
 ! only use for NCEP IC and GFDL microphy
 !-----------------------------------------------------------------------
    if (trim(source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and.        &
-       trim(source) /= 'FV3GFS GAUSSIAN NETCDF FILE'       ) then
+       trim(source) /= 'FV3GFS GAUSSIAN NETCDF FILE' .and.        &
+       trim(source) /= 'FV3GFS GRIB2 FILE'                 ) then
       if ((Atm%flagstruct%nwat .eq. 3 .or. Atm%flagstruct%nwat .eq. 6) .and. &
            (Atm%flagstruct%ncep_ic .or. Atm%flagstruct%nggps_ic)) then
          do k=1,npz
@@ -3463,7 +3468,7 @@ contains
             enddo
          enddo
       endif
-  endif ! data source /= FV3GFS GAUSSIAN NEMSIO/NETCDF FILE
+  endif ! data source /= FV3GFS GAUSSIAN NEMSIO/NETCDF and GRIB2 FILE
 
 ! For GFS spectral input, omega in pa/sec is stored as w in the input data so actual w(m/s) is calculated
 ! For GFS nemsio input, omega is 0, so best not to use for input since boundary data will not exist for w
@@ -3479,7 +3484,8 @@ contains
       enddo
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
     if (trim(source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
-        trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE'      ) then
+        trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        &
+        trim(source) == 'FV3GFS GRIB2 FILE'                ) then
       do k=1,npz
          do i=is,ie
             atm%w(i,j,k) = qn1(i,k)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -196,7 +196,7 @@ module external_ic_mod
    real, parameter:: zvir = rvgas/rdgas - 1.
    real(kind=R_GRID), parameter :: cnst_0p20=0.20d0
    real, parameter :: deg2rad = pi/180.
-   integer:: src_grp   ! source group
+   integer:: data_source_group
    public get_external_ic, get_cubed_sphere_terrain
    public remap_scalar, remap_dwinds
 
@@ -571,8 +571,8 @@ contains
       ! *DH 20200922
 
 !
-      call get_data_source(src_grp,Atm%flagstruct%regional)
-      if ( src_grp==1 ) then
+      call get_data_source(data_source_group,Atm%flagstruct%regional)
+      if ( data_source_group==1 ) then
          call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NEMSIO/NETCDF/GRIB2 FILE")
       endif
 !
@@ -841,7 +841,7 @@ contains
         snowwat = get_tracer_index(MODEL_ATMOS, 'snowwat')
         graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
         ntclamt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
-        if ( src_grp==1 ) then
+        if ( data_source_group==1 ) then
         do k=1,npz
           do j=js,je
             do i=is,ie
@@ -3230,7 +3230,7 @@ contains
   endif
 
 !$OMP parallel do default(none) &
-!$OMP             shared(sphum,liq_wat,rainwat,ice_wat,snowwat,graupel,liq_aero,ice_aero,src_grp,   &
+!$OMP             shared(sphum,liq_wat,rainwat,ice_wat,snowwat,graupel,liq_aero,ice_aero,data_source_group, &
 !$OMP                    cld_amt,ncnst,npz,is,ie,js,je,km,k2,ak0,bk0,psc,t_in,zh,omga,qa,Atm,z500) &
 !$OMP             private(l,m,pst,pn,gz,pe0,pn0,pe1,pn1,dp2,qp,qn1,gz_fv)
   do 5000 j=js,je
@@ -3374,7 +3374,7 @@ contains
 !----------------------------------------------------
 ! Compute true temperature using hydrostatic balance
 !----------------------------------------------------
-      if ( src_grp/=1 .or. .not. present(t_in)  ) then
+      if ( data_source_group/=1 .or. .not. present(t_in)  ) then
         do k=1,npz
 #ifdef MULTI_GASES
            Atm%pt(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*virq(Atm%q(i,j,k,:)) )
@@ -3409,7 +3409,7 @@ contains
 ! seperate cloud water and cloud ice from Jan-Huey Chen's HiRAM code
 ! only use for NCEP IC and GFDL microphy
 !-----------------------------------------------------------------------
-   if ( src_grp/=1 ) then
+   if ( data_source_group/=1 ) then
       if ((Atm%flagstruct%nwat .eq. 3 .or. Atm%flagstruct%nwat .eq. 6) .and. &
            (Atm%flagstruct%ncep_ic .or. Atm%flagstruct%nggps_ic)) then
          do k=1,npz
@@ -3473,7 +3473,7 @@ contains
          enddo
       enddo
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
-    if ( src_grp==1 ) then
+    if ( data_source_group==1 ) then
       do k=1,npz
          do i=is,ie
             atm%w(i,j,k) = qn1(i,k)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -196,8 +196,7 @@ module external_ic_mod
    real, parameter:: zvir = rvgas/rdgas - 1.
    real(kind=R_GRID), parameter :: cnst_0p20=0.20d0
    real, parameter :: deg2rad = pi/180.
-   character(len=80), public:: source
-   character(len=26), parameter:: data_source_fv3gfs='FV3GFS NEMSIO/NETCDF/GRIB2'
+   logical :: data_source_fv3gfs
    public get_external_ic, get_cubed_sphere_terrain
    public remap_scalar, remap_dwinds
 
@@ -572,8 +571,8 @@ contains
       ! *DH 20200922
 
 !
-      call get_data_source(source,Atm%flagstruct%regional)
-      if ( trim(source)==data_source_fv3gfs ) then
+      call get_data_source(data_source_fv3gfs,Atm%flagstruct%regional)
+      if ( data_source_fv3gfs ) then
          call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NEMSIO/NETCDF/GRIB2 FILE")
       endif
 !
@@ -842,7 +841,7 @@ contains
         snowwat = get_tracer_index(MODEL_ATMOS, 'snowwat')
         graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
         ntclamt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
-        if ( trim(source)==data_source_fv3gfs ) then
+        if ( data_source_fv3gfs ) then
         do k=1,npz
           do j=js,je
             do i=is,ie
@@ -3231,7 +3230,7 @@ contains
   endif
 
 !$OMP parallel do default(none) &
-!$OMP             shared(sphum,liq_wat,rainwat,ice_wat,snowwat,graupel,liq_aero,ice_aero,source, &
+!$OMP             shared(sphum,liq_wat,rainwat,ice_wat,snowwat,graupel,liq_aero,ice_aero,data_source_fv3gfs, &
 !$OMP                    cld_amt,ncnst,npz,is,ie,js,je,km,k2,ak0,bk0,psc,t_in,zh,omga,qa,Atm,z500) &
 !$OMP             private(l,m,pst,pn,gz,pe0,pn0,pe1,pn1,dp2,qp,qn1,gz_fv)
   do 5000 j=js,je
@@ -3375,7 +3374,7 @@ contains
 !----------------------------------------------------
 ! Compute true temperature using hydrostatic balance
 !----------------------------------------------------
-      if ( trim(source)/=data_source_fv3gfs .or. .not. present(t_in)  ) then
+      if ( .not.data_source_fv3gfs .or. .not. present(t_in)  ) then
         do k=1,npz
 #ifdef MULTI_GASES
            Atm%pt(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*virq(Atm%q(i,j,k,:)) )
@@ -3410,7 +3409,7 @@ contains
 ! seperate cloud water and cloud ice from Jan-Huey Chen's HiRAM code
 ! only use for NCEP IC and GFDL microphy
 !-----------------------------------------------------------------------
-   if ( trim(source)/=data_source_fv3gfs ) then
+   if ( .not.data_source_fv3gfs ) then
       if ((Atm%flagstruct%nwat .eq. 3 .or. Atm%flagstruct%nwat .eq. 6) .and. &
            (Atm%flagstruct%ncep_ic .or. Atm%flagstruct%nggps_ic)) then
          do k=1,npz
@@ -3474,7 +3473,7 @@ contains
          enddo
       enddo
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
-    if ( trim(source)==data_source_fv3gfs ) then
+    if ( data_source_fv3gfs ) then
       do k=1,npz
          do i=is,ie
             atm%w(i,j,k) = qn1(i,k)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -572,12 +572,8 @@ contains
 
 !
       call get_data_source(source,Atm%flagstruct%regional)
-      if (trim(source) == 'FV3GFS GAUSSIAN NEMSIO FILE') then
-         call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NEMSIO FILE")
-      else if (trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE') then
-         call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NETCDF FILE")
-      else if (trim(source) == 'FV3GFS GRIB2 FILE') then
-         call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS GRIB2 FILE")
+      if (trim(source) == 'FV3GFS NEMSIO/NETCDF/GRIB2 FILE') then
+         call mpp_error(NOTE, "READING FROM REGRIDDED FV3GFS NEMSIO/NETCDF/GRIB2 FILE")
       endif
 !
 !--- read in ak and bk from the gfs control file using fms_io read_data ---
@@ -845,9 +841,7 @@ contains
         snowwat = get_tracer_index(MODEL_ATMOS, 'snowwat')
         graupel = get_tracer_index(MODEL_ATMOS, 'graupel')
         ntclamt = get_tracer_index(MODEL_ATMOS, 'cld_amt')
-        if (trim(source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        & 
-            trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        &
-            trim(source) == 'FV3GFS GRIB2 FILE'                ) then
+        if ( trim(source)=='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
         do k=1,npz
           do j=js,je
             do i=is,ie
@@ -3380,9 +3374,7 @@ contains
 !----------------------------------------------------
 ! Compute true temperature using hydrostatic balance
 !----------------------------------------------------
-      if ( (trim(source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and. &  
-            trim(source) /= 'FV3GFS GAUSSIAN NETCDF FILE' .and. &
-            trim(source) /= 'FV3GFS GRIB2 FILE') .or. .not. present(t_in)  ) then
+      if ( trim(source)/='FV3GFS NEMSIO/NETCDF/GRIB2 FILE' .or. .not. present(t_in)  ) then
         do k=1,npz
 #ifdef MULTI_GASES
            Atm%pt(i,j,k) = (gz_fv(k)-gz_fv(k+1))/( rdgas*(pn1(i,k+1)-pn1(i,k))*virq(Atm%q(i,j,k,:)) )
@@ -3417,9 +3409,7 @@ contains
 ! seperate cloud water and cloud ice from Jan-Huey Chen's HiRAM code
 ! only use for NCEP IC and GFDL microphy
 !-----------------------------------------------------------------------
-   if (trim(source) /= 'FV3GFS GAUSSIAN NEMSIO FILE' .and.        &
-       trim(source) /= 'FV3GFS GAUSSIAN NETCDF FILE' .and.        &
-       trim(source) /= 'FV3GFS GRIB2 FILE'                 ) then
+   if ( trim(source) /= 'FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
       if ((Atm%flagstruct%nwat .eq. 3 .or. Atm%flagstruct%nwat .eq. 6) .and. &
            (Atm%flagstruct%ncep_ic .or. Atm%flagstruct%nggps_ic)) then
          do k=1,npz
@@ -3483,9 +3473,7 @@ contains
          enddo
       enddo
       call mappm(km, pe0, qp, npz, pe1, qn1, is,ie, -1, 4, Atm%ptop)
-    if (trim(source) == 'FV3GFS GAUSSIAN NEMSIO FILE' .or.        &
-        trim(source) == 'FV3GFS GAUSSIAN NETCDF FILE' .or.        &
-        trim(source) == 'FV3GFS GRIB2 FILE'                ) then
+    if ( trim(source) == 'FV3GFS NEMSIO/NETCDF/GRIB2 FILE' ) then
       do k=1,npz
          do i=is,ie
             atm%w(i,j,k) = qn1(i,k)


### PR DESCRIPTION
**Description**
- Add 'netcdf' and 'grib2' to the input 'source' option in the regional IC/LBC routines.
- Since the logic of 'netcdf' or 'grib2' in the code is the same as that of 'nemsio', these three types are put in the same category.
- The data source strings including the old one for 'nemsio' is changed to the logical flag 'data_source_fv3gfs'.

Fixes #97


**How Has This Been Tested?**
- Passed the regression test of the ufs weather model on WCOSS (dell/cray) and Hera with intel compiler.
- Completed a LAMDA test successfully with 'netcdf' input files from GFS.


**Checklist:**
Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules


**Contributors**
@JamesAbeles-NOAA, @EricRogers-NOAA
