### PR TITLE
Removing a duplicate use statement of FMS function "write_version_number"

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -27,7 +27,7 @@ module fv_diagnostics_mod
  use constants_mod,      only: grav, rdgas, rvgas, pi=>pi_8, radius, kappa, WTMAIR, WTMCO2, &
                                omega, hlv, cp_air, cp_vapor, TFREEZE
  use fms_mod,            only: write_version_number
- use fms_io_mod,         only: set_domain, nullify_domain, write_version_number
+ use fms_io_mod,         only: set_domain, nullify_domain
  use time_manager_mod,   only: time_type, get_date, get_time
  use mpp_domains_mod,    only: domain2d, mpp_update_domains, DGRID_NE, NORTH, EAST
  use diag_manager_mod,   only: diag_axis_init, register_diag_field, &


### PR DESCRIPTION
**Description**

The FMS 2021.02-beta1 testing tag code requires the ```write_version_number``` subroutine be loaded from fms_mod.  Any use of ```write_version_number``` from fms_io_mod will now give a compilation error.  tools/fv_diagnostics.F90 has loaded this subroutine via both fms_io_mod and fms_mod.  This PR removes the fms_io_mod ```write_version_number``` use statement

Fixes # (issue)

**How Has This Been Tested?**

I have verified this works when testing for PR #74. I have also verified that the code compiles with FMS tag 2021.02-beta1.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
