### PR TITLE
Merge latest master update into dev/gfdl

### DIFF
--- a/model/fv_tracer2d.F90
+++ b/model/fv_tracer2d.F90
@@ -715,7 +715,7 @@ subroutine tracer_2d_nested(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, np
       if (gridstruct%regional) then
             !This is more accurate than the nested BC calculation
             ! since it takes into account varying nsplit
-            reg_bc_update_time=current_time_in_seconds+(real(n_map-1) + real(it-1)/frac)*dt
+            reg_bc_update_time=current_time_in_seconds+(real(n_map-1) + real(it-1)*frac)*dt
             do iq=1,nq
                  call regional_boundary_update(q(:,:,:,iq), 'q', &
                                                isd, ied, jsd, jed, npz, &

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -27,7 +27,7 @@ module fv_diagnostics_mod
  use constants_mod,      only: grav, rdgas, rvgas, pi=>pi_8, radius, kappa, WTMAIR, WTMCO2, &
                                omega, hlv, cp_air, cp_vapor, TFREEZE
  use fms_mod,            only: write_version_number
- use fms_io_mod,         only: set_domain, nullify_domain, write_version_number
+ use fms_io_mod,         only: set_domain, nullify_domain
  use time_manager_mod,   only: time_type, get_date, get_time
  use mpp_domains_mod,    only: domain2d, mpp_update_domains, DGRID_NE, NORTH, EAST
  use diag_manager_mod,   only: diag_axis_init, register_diag_field, &


### PR DESCRIPTION
**Description**

Merge latest master update into dev/gfdl to fix an issue with a double use definition in fv_diagnostics.F90

**How Has This Been Tested?**

Preliminary tests have been run with the latest FMS beta tag indicating this needs to happen.  Since it is a one-line fix, it is expected it will work.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
