### PR TITLE
remove unused block of code for nudging after science updates

### DIFF
--- a/driver/GFDL/atmosphere.F90
+++ b/driver/GFDL/atmosphere.F90
@@ -1116,12 +1116,6 @@ contains
    if (query_cmip_diag_id(ID_tnhus)) &
                   used = send_cmip_data_3d (ID_tnhus, (Atm(mygrid)%q(isc:iec,jsc:jec,:,sphum)-qtend(:,:,:,sphum))/dt_atmos, Time)
 
-#if !defined(ATMOS_NUDGE) && !defined(CLIMATE_NUDGE) && !defined(ADA_NUDGE)
-   if ( .not.forecast_mode .and. Atm(mygrid)%flagstruct%nudge .and. Atm(mygrid)%flagstruct%na_init>0 ) then
-        if(mod(seconds, 21600)==0)  call adiabatic_init_drv (Time_prev, Time_next)
-   endif
-#endif
-
    call nullify_domain()
   !---- diagnostics for FV dynamics -----
    if (Atm(mygrid)%flagstruct%print_freq /= -99) then


### PR DESCRIPTION
**Description**

This update removes a block of code that is no longer being used within GFDL for nudging.  The code removed as preventing SPEAR model compilation.

Fixes # (issue)

**How Has This Been Tested?**

@uramirez8707  ran a test with the GFDL SPEAR model to confirm.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
