### PR TITLE
CPP/syntax errors found when running FV3 under NCAR CESM

### DIFF
--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -274,7 +274,11 @@ contains
       integer :: rainwat = -999, snowwat = -999, graupel = -999, cld_amt = -999
       integer :: theta_d = -999
       logical used, do_omega
+#ifdef MULTI_GASES
       integer, parameter :: max_packs=13
+#else
+      integer, parameter :: max_packs=12
+#endif
       type(group_halo_update_type), save :: i_pack(max_packs)
       integer :: is,  ie,  js,  je
       integer :: isd, ied, jsd, jed
@@ -630,7 +634,9 @@ contains
          enddo
       enddo
       if ( flagstruct%trdm2 > 1.e-4 ) then
+#ifdef MULTI_GASES
          call start_group_halo_update(i_pack(13), dp1, domain)
+#endif
       endif
 
       if ( n_map==k_split ) last_step = .true.
@@ -676,18 +682,27 @@ contains
        !!! CLEANUP: merge these two calls?
        if (gridstruct%bounded_domain) then
          call tracer_2d_nested(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, npx, npy, npz, nq,    &
-                        flagstruct%hord_tr, q_split, mdt, idiag%id_divg, i_pack(10), i_pack(13), &
+                        flagstruct%hord_tr, q_split, mdt, idiag%id_divg, i_pack(10), &
+#ifdef MULTI_GASES
+                        i_pack(13), &
+#endif
                         flagstruct%nord_tr, flagstruct%trdm2, &
                         k_split, neststruct, parent_grid, n_map, flagstruct%lim_fac)
        else
          if ( flagstruct%z_tracer ) then
-            call tracer_2d_1L(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, npx, npy, npz, nq,    &
-                 flagstruct%hord_tr, q_split, mdt, idiag%id_divg, i_pack(10), i_pack(13), &
-                 flagstruct%nord_tr, flagstruct%trdm2, flagstruct%lim_fac)
+         call tracer_2d_1L(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, npx, npy, npz, nq,    &
+                 flagstruct%hord_tr, q_split, mdt, idiag%id_divg, i_pack(10), &
+#ifdef MULTI_GASES
+                        i_pack(13), &
+#endif
+                        flagstruct%nord_tr, flagstruct%trdm2, flagstruct%lim_fac)
          else
-            call tracer_2d(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, npx, npy, npz, nq,    &
-                 flagstruct%hord_tr, q_split, mdt, idiag%id_divg, i_pack(10), i_pack(13), &
-                 flagstruct%nord_tr, flagstruct%trdm2, flagstruct%lim_fac)
+         call tracer_2d(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, npx, npy, npz, nq,    &
+                 flagstruct%hord_tr, q_split, mdt, idiag%id_divg, i_pack(10), &
+#ifdef MULTI_GASES
+                        i_pack(13), &
+#endif
+                        flagstruct%nord_tr, flagstruct%trdm2, flagstruct%lim_fac)
          endif
        endif
                                              call timing_off('tracer_2d')

--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -944,6 +944,7 @@ contains
          do i=is,ie
             qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)
          enddo
+      enddo
    else
       do k=1,kbot
          do i=is,ie

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -456,7 +456,7 @@ contains
 !>       Q   -  prognostic tracer fields
 !> Namelist variables
 !>       filtered_terrain  -  use orography maker filtered terrain mapping
-#ifdef __PGI
+#if defined(__PGI) && defined(GFS_PHYS)
       use GFS_restart, only : GFS_restart_type
 
       implicit none
@@ -1791,7 +1791,7 @@ contains
 !>@authors Jan-Huey Chen, Xi Chen, Shian-Jiann Lin
   subroutine get_ecmwf_ic( Atm, fv_domain )
 
-#ifdef __PGI
+#if defined(__PGI) && defined(GFS_PHYS)
       use GFS_restart, only : GFS_restart_type
 
       implicit none

--- a/tools/fv_diag_column.F90
+++ b/tools/fv_diag_column.F90
@@ -10,6 +10,7 @@ module fv_diag_column_mod
                                 mpp_max, NOTE, input_nml_file, get_unit
   use mpp_io_mod,         only: mpp_flush
   use fv_sg_mod,          only: qsmith
+  use fms_mod,            only: open_namelist_file, close_file
 
   implicit none
   private
@@ -60,6 +61,7 @@ contains
 
    integer :: ios, nlunit
    logical :: exists
+   character(len=64) :: errmsg
 
    call write_version_number ( 'FV_DIAG_COLUMN_MOD', version )
 
@@ -87,11 +89,11 @@ contains
       write(errmsg,*) 'fv_diag_column_nml: namelist file ',trim(Atm%nml_filename),' does not exist'
       call mpp_error(FATAL, errmsg)
     else
-      open (unit=nlunit, file=Atm%nml_filename, READONLY, status='OLD', iostat=ios)
+      nlunit=open_namelist_file(Atm%nml_filename)
     endif
     rewind(nlunit)
     read (nlunit, nml=fv_diag_column_nml, iostat=ios)
-    close (nlunit)
+    call close_file(nlunit)
 #endif
 
     if (do_diag_debug .or. do_diag_sonde) then

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -141,6 +141,7 @@ module fv_diagnostics_mod
  use sat_vapor_pres_mod, only: compute_qs, lookup_es
 
  use fv_arrays_mod, only: max_step
+ use fms_mod,            only: open_namelist_file, close_file
 
 #ifndef GFS_PHYS
  use gfdl_cloud_microphys_mod, only: wqs1, qsmith_init, c_liq
@@ -444,11 +445,11 @@ contains
       write(errmsg,*) 'fv_diag_plevs_nml: namelist file ',trim(Atm(n)%nml_filename),' does not exist'
       call mpp_error(FATAL, errmsg)
     else
-      open (unit=nlunit, file=Atm(n)%nml_filename, READONLY, status='OLD', iostat=ios)
+      nlunit=open_namelist_file(Atm(n)%nml_filename)
     endif
     rewind(nlunit)
     read (nlunit, nml=fv_diag_plevs_nml, iostat=ios)
-    close (nlunit)
+    call close_file(nlunit)
 #endif
     if (nplev > MAX_PLEVS) then
        if (is_master()) then


### PR DESCRIPTION
**Description**
While porting FV3 to the NCAR CESM framework we ran into issues with the MULTI_GASES and GLOBAL_CFL CPP definitions.  Since we are not using GFS physics and have implemented some FV3 features like MULTI_GASES in our own way, we are most likely hitting bugs while traversing code paths that are not typically run. These changes were tested in our port of FV3 but not in any publically released version by GFDL. These changes should be bit for bit when tested in your normal configuration but we were unable to verify that and they should be run through regression testing.  I'm happy to work with your SE's to come up with a testing strategy that will make the PR process easier.  NCAR CESM is currently running with a fork of FV3 which contains these bug fixes and a few other code modifications.  It is our hope to work with GFDL to help generalize the portability of FV3 where we can use the official GFDL repository directly as our FV3 external. 

Files Changed:

. model/fv_dynamics.F90 
--- Code didn't compile/run when MULTI_GASES was not defined.  We fixed the issue by additional CPP definitions of MULTI_GASES as well as modifications to fv_tracer2d.F90

. model/fv_sg.F90
---  Missing enddo statement

. model/fv_tracer2d.F90
---MULTI_GASES CPP updates
--- cmax not set correctly when GLOBAL_CFL is not defined.  **Here is a fix that we are running with but will need guidance for an official fix.**

. tools/external_ic.F90
--- use of GFS physics code should be wrapped by if defined (GFS_PHYS)

. tools/fv_diag_column.F90
. tools/fv_diagnostics.F90
--- I believe nlunit was undefined in these routines when running without INTERNAL_FILE_NML defined.


Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue) - NA


**How Has This Been Tested?**
This code is being run in the NCAR Community Atmosphere Model and is compiled with Intel.  If there is a public model that is supported on our systems (Cheyenne or Linux cluster) I could test these further or perhaps we can coordinate with DTC to help validate the changes if needed. Some of these issues are compile-time errors and others where caught at runtime when trying to use an uninitialized variable.

We are running the hydrostatic option for FV3 and these are the relevant CPP variables that were undefined.
GFS_PHYS not defined
MULTI_GASES not defined
GLOBAL_CFL not defined
INTERNAL_FILE_NML not defined


**Checklist:**

I'm unfamiliar with the style guidelines for coding and will need a pointer, I just tried to follow what was already there.


Please check all whether they apply or not
- [    ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [    ] I have commented my code, particularly in hard-to-understand areas
- [    ] I have made corresponding changes to the documentation
- [    ] My changes generate no new warnings
- [    ] Any dependent changes have been merged and published in downstream modules
