### PR TITLE
Adding Issue Templates to Repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve
+title: ''
+labels: Bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is
+
+**To Reproduce**
+Steps to reproduce the behavior
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System Environment**
+Describe the system environment, include:
+- OS: [e.g. RHEL 7.2]
+- Compiler(s): Type and version [e.g. Intel 19.1]
+- MPI type, and version (e.g. MPICH, Cray MPI, openMPI)
+- netCDF Version: For both C and Fortran
+- Configure options: Any additional flags, or macros passed to configure
+
+**Additional context**
+Add any other context about the problem.  If applicable, include where any files
+that help describe, or reproduce the problem exist.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,14 @@
+---
+name: Support request
+about: Request for help
+title: ''
+labels: 'question'
+assignees: ''
+---
+
+**Is your question related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe what you have tried**
+A clear and concise description of what steps you have taken.  Include command
+lines, and any messages from the command.


### PR DESCRIPTION
**Description**

This PR adds Issue Templates to be used in the GFDL_atmos_cubed_sphere repository.  There are 3 templates being included: feature request, support request, and bug report. These templates are derived from the FMS repository's issue templates.

Fixes # (issue)

**How Has This Been Tested?**

These templates can be tested by reviewers by navigating to my fork and creating test issues.  You will have the choice of the 3 templates when you go to create an issue.  I have tested this with 3 separate issues in my fork:
[bug report test](https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere/issues/2)
[feature request test](https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere/issues/3)
[support request test test](https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere/issues/4)

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
