### PR TITLE
Typo fix in fv_io.F90

### DIFF
--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -1249,8 +1249,8 @@ contains
     character(len=1)                   :: tile_num
     character(len=120)                 :: fname_ne, fname_sw
 
-    fname_ne = 'RESTART/fv_BC_ne.res.nc'
-    fname_sw = 'RESTART/fv_BC_sw.res.nc'
+    fname_ne = 'INPUT/fv_BC_ne.res.nc'
+    fname_sw = 'INPUT/fv_BC_sw.res.nc'
 
     allocate(all_pelist(mpp_npes()))
     call mpp_get_current_pelist(all_pelist)


### PR DESCRIPTION
**Description**

When we read in boundary condition restarts in fv_io, I had incorrectly referenced the RESTART directory when implementing fms2_io.  This PR corrects that to reference the INPUT directory.  

Fixes # (issue)

**How Has This Been Tested?**

Tested on Gaea with the C48n4 test reading from restarts.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
