### PR TITLE
Initialize {sw,se,nw,ne}_corner to .false. in model/fv_arrays.F90

### DIFF
--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -165,7 +165,7 @@ module fv_arrays_mod
 
      real(kind=R_GRID) :: global_area
      logical :: g_sum_initialized = .false. !< Not currently used but can be useful
-     logical:: sw_corner, se_corner, ne_corner, nw_corner
+     logical:: sw_corner = .false., se_corner = .false., ne_corner = .false., nw_corner = .false.
 
      real(kind=R_GRID) :: da_min, da_max, da_min_c, da_max_c
 


### PR DESCRIPTION
**Description**

Four logical flags (sw_corner, se_corner, ...) are initialized to .false. Related to #41 and #42.
When we run regression tests on Hera using gnu compiler we get this error (sometimes):

 ```
11: At line 1002 of file /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/ufs/labels/ufs-weather-model/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
 11: Fortran runtime error: Index '1' of dimension 2 of array 'grid' outside of expected range (34:52)
 11:
 11: Error termination. Backtrace:
 11: #0  0x2acd139 in __fv_grid_tools_mod_MOD_init_grid
 11:    at /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/ufs/labels/ufs-weather-model/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90:1002
 11: #1  0x247f552 in __fv_control_mod_MOD_fv_control_init
 11:    at /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/ufs/labels/ufs-weather-model/FV3/atmos_cubed_sphere/model/fv_control.F90:726
 11: #2  0x239efa0 in __atmosphere_mod_MOD_atmosphere_init
 11:    at /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/ufs/labels/ufs-weather-model/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90:580
 11: #3  0x211088c in __atmos_model_mod_MOD_atmos_model_init
 11:    at /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/ufs/labels/ufs-weather-model/FV3/atmos_model.F90:414
 11: #4  0x1f2344e in fcst_initialize
 11:    at /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/ufs/labels/ufs-weather-model/FV3/module_fcst_grid_comp.F90:405

```
Fixes # (issue)

**How Has This Been Tested?**

Regression tests in ufs-weather-model has been run on Hera using Intel and GNU compilers.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
