### PR TITLE
read ak/bk from user specified files

### DIFF
--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -587,6 +587,7 @@ module fv_arrays_mod
 #else
    character(24) :: npz_type = ''  !< Option for selecting vertical level setup (empty by default)
 #endif
+   character(120) :: fv_eta_file = 'global_hyblev_fcst.txt'  !< FV3 user specified eta file
    integer :: npz_rst = 0    !< If using a restart file with a different number of vertical
                              !< levels, set npz_rst to be the number of levels in your restart file.
                              !< The model will then remap the restart file data to the vertical coordinates

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -297,6 +297,7 @@ module fv_control_mod
      integer , pointer :: npy
      integer , pointer :: npz
      character(len=24), pointer :: npz_type
+     character(len=120), pointer :: fv_eta_file 
      integer , pointer :: npz_rst
 
      integer , pointer :: ncnst
@@ -864,6 +865,7 @@ module fv_control_mod
        npy                           => Atm%flagstruct%npy
        npz                           => Atm%flagstruct%npz
        npz_type                      => Atm%flagstruct%npz_type
+       fv_eta_file                   => Atm%flagstruct%fv_eta_file
        npz_rst                       => Atm%flagstruct%npz_rst
        ncnst                         => Atm%flagstruct%ncnst
        pnats                         => Atm%flagstruct%pnats
@@ -1429,7 +1431,7 @@ module fv_control_mod
 !!
 !!
 !> @{
-       namelist /fv_core_nml/npx, npy, ntiles, npz, npz_type, npz_rst, layout, io_layout, ncnst, nwat,  &
+       namelist /fv_core_nml/npx, npy, ntiles, npz, npz_type, fv_eta_file, npz_rst, layout, io_layout, ncnst, nwat,  &
             use_logp, p_fac, a_imp, k_split, n_split, m_split, q_split, print_freq, write_3d_diags, &
             do_schmidt, do_cube_transform, &
             hord_mt, hord_vt, hord_tm, hord_dp, hord_tr, shift_fac, stretch_fac, target_lat, target_lon, &

--- a/model/fv_grid_utils.F90
+++ b/model/fv_grid_utils.F90
@@ -246,7 +246,7 @@
       elseif ( .not. Atm%flagstruct%hybrid_z ) then
 ! Initialize (ak,bk) for cold start; overwritten with restart file
            if (.not. Atm%flagstruct%external_eta) then
-              call set_eta(npz, Atm%ks, Atm%ptop, Atm%ak, Atm%bk, Atm%flagstruct%npz_type)
+              call set_eta(npz, Atm%ks, Atm%ptop, Atm%ak, Atm%bk, Atm%flagstruct%npz_type, Atm%flagstruct%fv_eta_file)
               if ( is_master() ) then
                  write(*,*) 'Grid_init', npz, Atm%ks, Atm%ptop
                  tmp1 = Atm%ak(Atm%ks+1)

--- a/tools/fv_eta.F90
+++ b/tools/fv_eta.F90
@@ -351,6 +351,26 @@ module fv_eta_mod
          auto_routine = 2
       end select
 
+! Jili Dong add ak/bk input
+   else if (trim(npz_type) == 'input') then
+       open (113,file="global_hyblev_fcst.txt")
+       read(113,*)
+       do k=km+1,1,-1
+          read(113,*) ak(k),bk(k)
+       end do
+       close(113)
+
+       do k=1,km+1
+          if (bk(k) .eq. 0.0) then
+             ks=k
+             exit
+          end if
+       end do
+
+       ks=ks-2
+! Jili Dong add ak/bk input
+
+
    else
 
       select case (km)

--- a/tools/fv_eta.F90
+++ b/tools/fv_eta.F90
@@ -284,7 +284,7 @@ module fv_eta_mod
 
 #else
  !This is the version of set_eta used in SHiELD and AM4
- subroutine set_eta(km, ks, ptop, ak, bk, npz_type)
+ subroutine set_eta(km, ks, ptop, ak, bk, npz_type,fv_eta_file)
 
 !Level definitions are now in this header file
 #include <tools/fv_eta.h>
@@ -295,6 +295,8 @@ module fv_eta_mod
    real, intent(out):: bk(km+1)
    real, intent(out):: ptop         ! model top (Pa)
    character(24), intent(IN) :: npz_type
+   character(120), intent(IN) :: fv_eta_file 
+   integer :: eta_level_unit
 
    real:: p0=1000.E2
    real:: pc=200.E2
@@ -353,23 +355,14 @@ module fv_eta_mod
 
 ! Jili Dong add ak/bk input
    else if (trim(npz_type) == 'input') then
-       open (113,file="global_hyblev_fcst.txt")
-       read(113,*)
+       open (newunit=eta_level_unit, file=trim(fv_eta_file))
+       read(eta_level_unit,*)
        do k=km+1,1,-1
-          read(113,*) ak(k),bk(k)
+          read(eta_level_unit,*) ak(k),bk(k)
        end do
-       close(113)
-
-       do k=1,km+1
-          if (bk(k) .eq. 0.0) then
-             ks=k
-             exit
-          end if
-       end do
-
-       ks=ks-2
+       close(eta_level_unit)
+       call set_external_eta(ak, bk, ptop, ks)
 ! Jili Dong add ak/bk input
-
 
    else
 


### PR DESCRIPTION
**Description**


This code change adds a new option to read in a set of ak/bk specified by users for vertical coordinates. It provides an alternative and more flexible approach to specify eta, which is currently set in fv_eta.F90 and fv_eta.h. To use the option, set npz_type = "input". 

Fixes #116 

**How Has This Been Tested?**

It has been tested for regional FV3 in both parallel and experimental runs and works well for reading in user specified ak/bk.


**Checklist:**

Please check all whether they apply or not
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published in downstream modules
