### PR TITLE
removed module use of INPUT_STR_LENGTH in fv_control.F90 (#122)

### DIFF
--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -33,7 +33,7 @@ module fv_control_mod
    use mpp_mod,             only: FATAL, mpp_error, mpp_pe, stdlog, &
                                   mpp_npes, mpp_get_current_pelist, &
                                   input_nml_file, get_unit, WARNING, &
-                                  read_ascii_file, INPUT_STR_LENGTH
+                                  read_ascii_file
    use mpp_domains_mod,     only: mpp_get_data_domain, mpp_get_compute_domain, mpp_get_tile_id
    use tracer_manager_mod,  only: tm_get_number_tracers => get_number_tracers, &
                                   tm_get_tracer_index   => get_tracer_index,   &


### PR DESCRIPTION
**Description**
Removes the obsoleted INPUT_STR_LENGTH parameter included via module use option

**How Has This Been Tested?**
Compiles to verify it is no longer needed and SHiELD runs have completed with this fix.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
