### PR TITLE
Makes the non-hydrostatic restart variables optional for reads to allow hydrostatic IC

### DIFF
--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -260,12 +260,21 @@ contains
        call register_restart_field(Atm%Fv_restart_tile, 'v', Atm%v, dim_names_4d2)
 
        if (.not.Atm%flagstruct%hydrostatic) then
-          call register_restart_field(Atm%Fv_restart_tile,  'W', Atm%w, dim_names_4d3)
-          call register_restart_field(Atm%Fv_restart_tile,  'DZ', Atm%delz, dim_names_4d3)
-          if ( Atm%flagstruct%hybrid_z ) then
-             call register_restart_field(Atm%Fv_restart_tile,  'ZE0', Atm%ze0, dim_names_4d3)
+          if (Atm%flagstruct%make_nh) then ! Hydrostatic restarts dont have these variables
+               call register_restart_field(Atm%Fv_restart_tile,  'W', Atm%w, dim_names_4d3, is_optional=.true.)
+               call register_restart_field(Atm%Fv_restart_tile,  'DZ', Atm%delz, dim_names_4d3, is_optional=.true.)
+               if ( Atm%flagstruct%hybrid_z ) then
+                   call register_restart_field(Atm%Fv_restart_tile,  'ZE0', Atm%ze0, dim_names_4d3, is_optional=.true.)
+               endif
+          else !The restart file has the non-hydrostatic variables 
+               call register_restart_field(Atm%Fv_restart_tile,  'W', Atm%w, dim_names_4d3)
+               call register_restart_field(Atm%Fv_restart_tile,  'DZ', Atm%delz, dim_names_4d3)
+               if ( Atm%flagstruct%hybrid_z ) then
+                   call register_restart_field(Atm%Fv_restart_tile,  'ZE0', Atm%ze0, dim_names_4d3)
+               endif
           endif
        endif
+
        call register_restart_field(Atm%Fv_restart_tile,  'T', Atm%pt, dim_names_4d3)
        call register_restart_field(Atm%Fv_restart_tile,  'delp', Atm%delp, dim_names_4d3)
        call register_restart_field(Atm%Fv_restart_tile,  'phis', Atm%phis, dim_names_3d)


### PR DESCRIPTION

**Description**

Adds is_optional to a few of the non hydrostatic variables when read from a restart file. This allows the model to be started with hydrostatic restart files


Fixes #131 

**How Has This Been Tested?**

Non-hydrostatic GFDL aquaplanet initialized with hydrostatic ICs


**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
