### PR TITLE
Bug fix fv_regional_bc.F90: initialize cloud amount boundary conditions only if cloud amount is a valid tracer

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -3772,7 +3772,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
             BC_side%q_BC(i,j,k,rainwat) = 0.
             BC_side%q_BC(i,j,k,snowwat) = 0.
             BC_side%q_BC(i,j,k,graupel) = 0.
-            BC_side%q_BC(i,j,k,cld_amt) = 0.
+            if (cld_amt > 0) BC_side%q_BC(i,j,k,cld_amt) = 0.
             if ( BC_side%pt_BC(i,j,k) > 273.16 ) then       ! > 0C all liq_wat
                BC_side%q_BC(i,j,k,liq_wat) = qn1(i,k)
                BC_side%q_BC(i,j,k,ice_wat) = 0.


### PR DESCRIPTION
**Description**

As the title says. In `model/fv_regional_bc.F90`, initialize cloud amount boundary conditions to zero only if cloud amount is a valid tracer (i.e. if the index in the tracer array is > 0).

Fixes https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/145

Tested in the latest ufs-weather-model for regression tests that are run only sporadically (`rt_ccpp_dev.conf`), i.e. not as part of the standard Intel/GNU tests. This solves a crash with old input data that was generated for Thompson MP and doesn't have cloud amount.

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
