### PR TITLE
Better error message from CCPP in case call to ccpp_physics_run for group 'fast_physics' failed

### DIFF
--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -840,7 +840,10 @@ endif        ! end last_step check
     ! Call to CCPP fast_physics group
     if (cdata%initialized()) then
       call ccpp_physics_run(cdata, suite_name=trim(ccpp_suite), group_name='fast_physics', ierr=ierr)
-      if (ierr/=0) call mpp_error(FATAL, "Call to ccpp_physics_run for group 'fast_physics' failed")
+      if (ierr/=0) then
+        call mpp_error(NOTE, trim(cdata%errmsg))
+        call mpp_error(FATAL, "Call to ccpp_physics_run for group 'fast_physics' failed")
+      endif
     else
       call mpp_error (FATAL, 'Lagrangian_to_Eulerian: can not call CCPP fast physics because CCPP not initialized')
     endif


### PR DESCRIPTION
**Description**

As the title says: Better error message from CCPP in case call to ccpp_physics_run for group 'fast_physics' failed. Without this change, the actual error message that is written to `cdata%errmsg` by the physics is not written to stderr and then user only gets "Call to ccpp_physics_run for group 'fast_physics' failed".

**How Has This Been Tested?**

ufs-weather-model regression tests (see **MISSING**)

Associated PRs:

**MISSING**

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
