### PR TITLE
Fix undeclared variable/routines in namelist IO

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -154,7 +154,8 @@ use fms_mod,                only: error_mesg, FATAL,                 &
                                   write_version_number,              &
                                   mpp_clock_id, mpp_clock_begin,     &
                                   mpp_clock_end, CLOCK_SUBCOMPONENT, &
-                                  clock_flag_default
+                                  clock_flag_default,                &
+                                  open_namelist_file, close_file
 use fms2_io_mod,            only: file_exists
 use mpp_mod,                only: mpp_error, stdout, FATAL, WARNING, NOTE, &
                                   input_nml_file, mpp_root_pe,    &
@@ -476,13 +477,13 @@ contains
    read(input_nml_file, nml=atmos_model_nml, iostat=io)
    ierr = check_nml_error(io, 'atmos_model_nml')
 #else
-   unit = open_namelist_file ( )
+   nlunit = open_namelist_file ( )
    ierr=1
    do while (ierr /= 0)
-      read  (unit, nml=atmos_model_nml, iostat=io, end=10)
+      read  (nlunit, nml=atmos_model_nml, iostat=io, end=10)
       ierr = check_nml_error(io,'atmos_model_nml')
    enddo
-10 call close_file (unit)
+10 call close_file (nlunit)
 #endif
    !write(0,'(a)') "It's me, and my physics suite is '" // trim(ccpp_suite) // "'"
    ! *DH 20210326


### PR DESCRIPTION
**Description**

This fixes a bug in `driver/fvGFS/atmosphere.F90` that causes compilation to fail when the code is built without `-DINTERNAL_FILE_NML`.  Specifically, where the namelist is read, the variable, `unit`, was not declared and the routines `open_namelist_file` and `close_file` were not available.  This fixes those issues.

**How Has This Been Tested?**

The code was successfully compiled and run with the Intel OneAPI 2021 compiler in an Ubuntu 20.04 container.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
