### PR TITLE
Addressing GNU Warnings

### DIFF
--- a/GFDL_tools/fv_ada_nudge.F90
+++ b/GFDL_tools/fv_ada_nudge.F90
@@ -1035,7 +1035,8 @@ endif
            pt0 = tm(i,j)/(pk0(km+1)-pk0(km))*(kappa*(pn0(km+1)-pn0(km)))
            pst = pk0(km+1) + (gz0(i,j)-phis(i,j))/(cp_air*pt0)
       endif
-666   ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+      ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+666   continue ! i-loop
       enddo   ! j-loop
 
       if( nf_ps>0 ) call del2_scalar(ps_dt, del2_cd, 1, nf_ps, bd, npx, npy, gridstruct, domain)

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -234,11 +234,11 @@ module fv_regional_mod
                            ,oro_data ='oro_data.tile7.halo4.nc'
 
 #ifdef OVERLOAD_R4
-      real, parameter:: real_snan=x'FFBFFFFF'
+      real, parameter:: real_snan=real(Z'FFBFFFFF')
 #else
-      real, parameter:: real_snan=x'FFF7FFFFFFFFFFFF'
+      real, parameter:: real_snan=real(Z'FFF7FFFFFFFFFFFF')
 #endif
-      real(kind=R_GRID), parameter:: dbl_snan=x'FFF7FFFFFFFFFFFF'
+      real(kind=R_GRID), parameter:: dbl_snan=real(Z'FFF7FFFFFFFFFFFF',kind=R_GRID)
 
       interface dump_field
         module procedure dump_field_3d

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -5081,17 +5081,20 @@ contains
 
       km1 = km - 1
 
-      do 500 k=2,km
-      do 500 i=1,im
-500   a6(i,k) = delp(i,k-1) + delp(i,k)
+      do k=2,km
+      do i=1,im
+      a6(i,k) = delp(i,k-1) + delp(i,k)
+      enddo
+      enddo
 
-      do 1000 k=1,km1
-      do 1000 i=1,im
+      do k=1,km1
+      do i=1,im
       delq(i,k) = p(i,k+1) - p(i,k)
-1000  continue
+      enddo
+      enddo
 
-      do 1220 k=2,km1
-      do 1220 i=1,im
+      do k=2,km1
+      do i=1,im
       c1 = (delp(i,k-1)+0.5*delp(i,k))/a6(i,k+1)
       c2 = (delp(i,k+1)+0.5*delp(i,k))/a6(i,k)
       tmp = delp(i,k)*(c1*delq(i,k) + c2*delq(i,k-1)) /    &
@@ -5099,7 +5102,8 @@ contains
       qmax = max(p(i,k-1),p(i,k),p(i,k+1)) - p(i,k)
       qmin = p(i,k) - min(p(i,k-1),p(i,k),p(i,k+1))
       dc(i,k) = sign(min(abs(tmp),qmax,qmin), tmp)
-1220  continue
+      enddo
+      enddo
 
 !****6***0*********0*********0*********0*********0*********0**********72
 ! 4th order interpolation of the provisional cell edge value

--- a/tools/fv_eta.F90
+++ b/tools/fv_eta.F90
@@ -809,7 +809,7 @@ module fv_eta_mod
   real ep, es, alpha, beta, gama
   real, parameter:: akap = 2./7.
 !---- Tunable parameters:
-  real:: k_inc = 10   ! # of layers from bottom up to near const dz region
+  integer:: k_inc = 10   ! # of layers from bottom up to near const dz region
   real:: s0 = 0.8     ! lowest layer stretch factor
 !-----------------------
   real:: s_inc

--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -800,7 +800,8 @@ module fv_nwp_nudge_mod
            pt0 = tm(i,j)/(pk0(km+1)-pk0(km))*(kappa*(pn0(km+1)-pn0(km)))
            pst = pk0(km+1) + (gz0(i,j)-phis(i,j))/(cp_air*pt0)
       endif
-666   ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+      ps_dt(i,j) = pst**(1./kappa) - ps(i,j)
+666   continue ! i-loop
       enddo   ! j-loop
 
       if( nf_ps>0 ) call del2_scalar(ps_dt, del2_cd, 1, nf_ps, bd, npx, npy, gridstruct, domain)


### PR DESCRIPTION
**Description**

These are fixes to the GCC 10.2.0 warnings
I have also added a change to fv_regional_bc so that the flag "-fallow-invalid-boz" is no longer needed for GNU compilation.

Fixes #78 

**How Has This Been Tested?**

Changes were tested with SHiELD model RTS tests

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
