### PR TITLE
update to external_ic::remap_scale to skip remapping non-existent IC tracers

### DIFF
--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -3084,6 +3084,7 @@ contains
 
 ! map tracers
       do iq=1,ncnst
+        if (floor(qa(is,j,1,iq)) == -1000) cycle !skip missing scalars [floor(-999.99) is -1000]
          do k=1,km
             do i=is,ie
                qp(i,k) = qa(i,j,k,iq)


### PR DESCRIPTION
**Description**

Fix to cycle the tracer remap loop in external_ic for tracers that do not appear in the ICs (denoted by an initial value of -999.99).

Fixes # (issue)
This fixes an issue created by PR #147 (see discussion near end)

**How Has This Been Tested?**

This has been tested on gaea in the [ufs-weather-model](https://github.com/ufs-community/ufs-weather-model) after making appropriate changes to the field_table (defining initial tracer profiles).

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
