### PR TITLE
fix for 4diau with iau_filter_increments=T

### DIFF
--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -298,7 +298,7 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    implicit none
    type (IPD_control_type), intent(in) :: IPD_Control
    type(IAU_external_data_type),  intent(inout) :: IAU_Data
-   real(kind=kind_phys) t1,t2,sx,wx,wt,dtp
+   real(kind=kind_phys) t1,t2,tnext,sx,wx,wt,dtp
    integer n,i,j,k,sphum,kstep,nstep
 
    IAU_Data%in_interval=.false.
@@ -353,7 +353,7 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    endif
 
    if (nfiles > 1) then
-      t2=2
+      tnext=2
       if (IPD_Control%fhour < t1 .or. IPD_Control%fhour >= t2) then
 !         if (is_master()) print *,'no iau forcing',IPD_Control%iaufhrs(1),IPD_Control%fhour,IPD_Control%iaufhrs(nfiles)
          IAU_Data%in_interval=.false.
@@ -362,16 +362,16 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
          IAU_Data%in_interval=.true.
          do k=nfiles,1,-1
             if (IPD_Control%iaufhrs(k) > IPD_Control%fhour) then
-               t2=k
+               tnext=k
             endif
          enddo
-!         if (is_master()) print *,'t2=',t2
+!         if (is_master()) print *,'tnext=',tnext
          if (IPD_Control%fhour >= iau_state%hr2) then ! need to read in next increment file
             iau_state%hr1=iau_state%hr2
-            iau_state%hr2=IPD_Control%iaufhrs(int(t2))
+            iau_state%hr2=IPD_Control%iaufhrs(int(tnext))
             iau_state%inc1=iau_state%inc2
-            if (is_master()) print *,'reading next increment file',trim(IPD_Control%iau_inc_files(int(t2)))
-            call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(int(t2))))
+            if (is_master()) print *,'reading next increment file',trim(IPD_Control%iau_inc_files(int(tnext)))
+            call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(int(tnext))))
          endif
          call updateiauforcing(IPD_Control,IAU_Data,iau_state%wt)
       endif

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -315,7 +315,7 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    endif
    if (IPD_Control%iau_filter_increments) then
       ! compute increment filter weight
-      ! t1 isbeginning of window, t2 end of window
+      ! t1 is beginning of window, t2 end of window
       ! IPD_Control%fhour current time
       ! in window kstep=-nstep,nstep (2*nstep+1 total)
       ! time step IPD_control%dtp
@@ -341,7 +341,9 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    if (nfiles.EQ.1) then
 !  on check to see if we are in the IAU window,  no need to update the
 !  tendencies since they are fixed over the window
-      if (IPD_Control%fhour < t1 .or. IPD_Control%fhour >= t2) then
+      if ( IPD_Control%fhour < t1 .or. IPD_Control%fhour >= t2 ) then
+!         if (is_master()) print *,'no iau forcing',t1,IPD_Control%fhour,t2
+         IAU_Data%in_interval=.false.
       else
          if (IPD_Control%iau_filter_increments) call setiauforcing(IPD_Control,IAU_Data,iau_state%wt)
          if (is_master()) print *,'apply iau forcing t1,t,t2,filter wt=',t1,IPD_Control%fhour,t2,iau_state%wt/iau_state%wt_normfact

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -253,6 +253,7 @@ subroutine IAU_initialize (IPD_Control, IAU_Data,Init_parm)
     allocate (iau_state%inc1%tracer_inc(is:ie, js:je, km,ntracers))
     iau_state%hr1=IPD_Control%iaufhrs(1)
     iau_state%wt = 1.0 ! IAU increment filter weights (default 1.0)
+    iau_state%wt_normfact = 1.0
     if (IPD_Control%iau_filter_increments) then
        ! compute increment filter weights, sum to obtain normalization factor
        dtp=IPD_control%dtp
@@ -305,17 +306,24 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
        return
    endif
 
+   if (nfiles .eq. 1) then 
+       t1 = IPD_Control%iaufhrs(1)-0.5*IPD_Control%iau_delthrs
+       t2 = IPD_Control%iaufhrs(1)+0.5*IPD_Control%iau_delthrs
+   else
+       t1 = IPD_Control%iaufhrs(1)
+       t2 = IPD_Control%iaufhrs(nfiles)
+   endif
    if (IPD_Control%iau_filter_increments) then
       ! compute increment filter weight
-      ! IPD_Control%iaufhrs(1) beginning of window, IPD_Control%iaufhrs(nfiles) end of window
+      ! t1 isbeginning of window, t2 end of window
       ! IPD_Control%fhour current time
       ! in window kstep=-nstep,nstep (2*nstep+1 total)
       ! time step IPD_control%dtp
       dtp=IPD_control%dtp
       nstep = 0.5*IPD_Control%iau_delthrs*3600/dtp
       ! compute normalized filter weight
-      kstep = ((IPD_Control%fhour-IPD_Control%iaufhrs(1)) - 0.5*IPD_Control%iau_delthrs)*3600./dtp
-      if (IPD_Control%fhour >= IPD_Control%iaufhrs(1) .and. IPD_Control%fhour < IPD_Control%iaufhrs(nfiles)) then
+      kstep = ((IPD_Control%fhour-t1) - 0.5*IPD_Control%iau_delthrs)*3600./dtp
+      if (IPD_Control%fhour >= t1 .and. IPD_Control%fhour < t2) then
          sx     = acos(-1.)*kstep/nstep
          wx     = acos(-1.)*kstep/(nstep+1)
          if (kstep .ne. 0) then
@@ -324,7 +332,7 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
             wt = 1.
          endif
          iau_state%wt = iau_state%wt_normfact*wt
-         if (is_master()) print *,'filter wt',kstep,IPD_Control%iaufhrs(1),IPD_Control%fhour,IPD_Control%iaufhrs(nfiles),iau_state%wt/iau_state%wt_normfact
+         !if (is_master()) print *,'kstep,t1,t,t2,filter wt=',kstep,t1,IPD_Control%fhour,t2,iau_state%wt/iau_state%wt_normfact
       else
          iau_state%wt = 0.
       endif
@@ -333,11 +341,10 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    if (nfiles.EQ.1) then
 !  on check to see if we are in the IAU window,  no need to update the
 !  tendencies since they are fixed over the window
-      if (IPD_Control%fhour < IPD_Control%iaufhrs(1) .or. IPD_Control%fhour >= IPD_Control%iaufhrs(nfiles)) then
-         IAU_Data%in_interval=.false.
+      if (IPD_Control%fhour < t1 .or. IPD_Control%fhour >= t2) then
       else
          if (IPD_Control%iau_filter_increments) call setiauforcing(IPD_Control,IAU_Data,iau_state%wt)
-         if (is_master()) print *,'apply iau forcing',IPD_Control%iaufhrs(1),IPD_Control%fhour,IPD_Control%iaufhrs(nfiles)
+         if (is_master()) print *,'apply iau forcing t1,t,t2,filter wt=',t1,IPD_Control%fhour,t2,iau_state%wt/iau_state%wt_normfact
          IAU_Data%in_interval=.true.
       endif
       return
@@ -345,11 +352,11 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
 
    if (nfiles > 1) then
       t2=2
-      if (IPD_Control%fhour < IPD_Control%iaufhrs(1) .or. IPD_Control%fhour >= IPD_Control%iaufhrs(nfiles)) then
+      if (IPD_Control%fhour < t1 .or. IPD_Control%fhour >= t2) then
 !         if (is_master()) print *,'no iau forcing',IPD_Control%iaufhrs(1),IPD_Control%fhour,IPD_Control%iaufhrs(nfiles)
          IAU_Data%in_interval=.false.
       else
-         if (is_master()) print *,'apply iau forcing',IPD_Control%iaufhrs(1),IPD_Control%fhour,IPD_Control%iaufhrs(nfiles)
+         if (is_master()) print *,'apply iau forcing t1,t,t2,filter wt=',t1,IPD_Control%fhour,t2,iau_state%wt/iau_state%wt_normfact
          IAU_Data%in_interval=.true.
          do k=nfiles,1,-1
             if (IPD_Control%iaufhrs(k) > IPD_Control%fhour) then

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -298,8 +298,8 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    implicit none
    type (IPD_control_type), intent(in) :: IPD_Control
    type(IAU_external_data_type),  intent(inout) :: IAU_Data
-   real(kind=kind_phys) t1,t2,tnext,sx,wx,wt,dtp
-   integer n,i,j,k,sphum,kstep,nstep
+   real(kind=kind_phys) t1,t2,sx,wx,wt,dtp
+   integer n,i,j,k,sphum,kstep,nstep,itnext
 
    IAU_Data%in_interval=.false.
    if (nfiles.LE.0) then
@@ -353,7 +353,7 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
    endif
 
    if (nfiles > 1) then
-      tnext=2
+      itnext=2
       if (IPD_Control%fhour < t1 .or. IPD_Control%fhour >= t2) then
 !         if (is_master()) print *,'no iau forcing',IPD_Control%iaufhrs(1),IPD_Control%fhour,IPD_Control%iaufhrs(nfiles)
          IAU_Data%in_interval=.false.
@@ -362,16 +362,16 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
          IAU_Data%in_interval=.true.
          do k=nfiles,1,-1
             if (IPD_Control%iaufhrs(k) > IPD_Control%fhour) then
-               tnext=k
+               itnext=k
             endif
          enddo
-!         if (is_master()) print *,'tnext=',tnext
+!         if (is_master()) print *,'itnext=',itnext
          if (IPD_Control%fhour >= iau_state%hr2) then ! need to read in next increment file
             iau_state%hr1=iau_state%hr2
-            iau_state%hr2=IPD_Control%iaufhrs(int(tnext))
+            iau_state%hr2=IPD_Control%iaufhrs(itnext)
             iau_state%inc1=iau_state%inc2
-            if (is_master()) print *,'reading next increment file',trim(IPD_Control%iau_inc_files(int(tnext)))
-            call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(int(tnext))))
+            if (is_master()) print *,'reading next increment file',trim(IPD_Control%iau_inc_files(itnext))
+            call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(itnext)))
          endif
          call updateiauforcing(IPD_Control,IAU_Data,iau_state%wt)
       endif


### PR DESCRIPTION
**Description**

This PR fixes a bug in the 4DIAU code when the parameter iau_filter_increments=T.  The time bounds for the IAU interval were computed incorrectly, leading to incorrect filter weights that were applied outside the designated time range.   The 4DIAU with constant weights, and 3DIAU (with a single increment file specified) were not affected by this bug.

Fixes https://github.com/ufs-community/ufs-weather-model/issues/989

**How Has This Been Tested?**

Regression tests pass on hera, cycling DA experiment with iau_filter_increments=T and hourly increment files ran on orion.

**Checklist:**

Please check all whether they apply or not
- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
