### PR TITLE
code changes for addressing a regional lateral boundary condition issue

### DIFF
--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -561,13 +561,13 @@ contains
                                       isd, ied, jsd, jed, npz, &
                                       is,  ie,  js,  je,       &
                                       isd, ied, jsd, jed,      &
-                                      reg_bc_update_time )
+                                      reg_bc_update_time,it )
 #ifndef SW_DYNAMICS
         call regional_boundary_update(ptc, 'pt', &
                                       isd, ied, jsd, jed, npz, &
                                       is,  ie,  js,  je,       &
                                       isd, ied, jsd, jed,      &
-                                      reg_bc_update_time )
+                                      reg_bc_update_time,it )
 #endif
       endif
       if ( hydrostatic ) then
@@ -727,12 +727,12 @@ contains
                                       isd, ied, jsd, jed+1, npz, &
                                       is,  ie,  js,  je,       &
                                       isd, ied, jsd, jed,      &
-                                      reg_bc_update_time )
+                                      reg_bc_update_time,it )
         call regional_boundary_update(uc, 'uc', &
                                       isd, ied+1, jsd, jed, npz, &
                                       is,  ie,  js,  je,       &
                                       isd, ied, jsd, jed,      &
-                                      reg_bc_update_time )
+                                      reg_bc_update_time,it )
         call mpp_update_domains(uc, vc, domain, gridtype=CGRID_NE)
 !!! Currently divgd is always 0.0 in the regional domain boundary area.
         reg_bc_update_time=current_time_in_seconds+bdt*(n_map-1)+(it-1)*dt
@@ -740,7 +740,7 @@ contains
                                       isd, ied+1, jsd, jed+1, npz, &
                                       is,  ie,  js,  je,       &
                                       isd, ied, jsd, jed,      &
-                                      reg_bc_update_time )
+                                      reg_bc_update_time,it )
       endif
 
     if ( flagstruct%inline_q ) then
@@ -758,7 +758,7 @@ contains
                                         isd, ied, jsd, jed, npz, &
                                         is,  ie,  js,  je,       &
                                         isd, ied, jsd, jed,      &
-                                        reg_bc_update_time )
+                                        reg_bc_update_time,it )
         enddo
       endif
 
@@ -996,20 +996,20 @@ contains
                                     isd, ied, jsd, jed, npz, &
                                     is,  ie,  js,  je,       &
                                     isd, ied, jsd, jed,      &
-                                    reg_bc_update_time )
+                                    reg_bc_update_time,it )
 #ifndef SW_DYNAMICS
       call regional_boundary_update(pt, 'pt', &
                                     isd, ied, jsd, jed, npz, &
                                     is,  ie,  js,  je,       &
                                     isd, ied, jsd, jed,      &
-                                    reg_bc_update_time )
+                                    reg_bc_update_time,it )
 
 #ifdef USE_COND
       call regional_boundary_update(q_con, 'q_con', &
                                     isd, ied, jsd, jed, npz, &
                                     is,  ie,  js,  je,       &
                                     isd, ied, jsd, jed,      &
-                                    reg_bc_update_time )
+                                    reg_bc_update_time,it )
 #endif
 
 #endif
@@ -1329,14 +1329,14 @@ contains
 
     if (flagstruct%regional) then
 
+           reg_bc_update_time=current_time_in_seconds+bdt*(n_map-1)+it*dt
 #ifndef SW_DYNAMICS
          if (.not. hydrostatic) then
-           reg_bc_update_time=current_time_in_seconds+bdt*(n_map-1)+it*dt
            call regional_boundary_update(w, 'w', &
                                          isd, ied, jsd, jed, ubound(w,3), &
                                          is,  ie,  js,  je,       &
                                          isd, ied, jsd, jed,      &
-                                         reg_bc_update_time )
+                                         reg_bc_update_time,it )
          endif
 #endif SW_DYNAMICS
 
@@ -1344,12 +1344,12 @@ contains
                                        isd, ied, jsd, jed+1, npz, &
                                        is,  ie,  js,  je,       &
                                        isd, ied, jsd, jed,      &
-                                       reg_bc_update_time )
+                                       reg_bc_update_time,it )
          call regional_boundary_update(v, 'v', &
                                        isd, ied+1, jsd, jed, npz, &
                                        is,  ie,  js,  je,       &
                                        isd, ied, jsd, jed,      &
-                                       reg_bc_update_time )
+                                       reg_bc_update_time,it )
 
          call mpp_update_domains(u, v, domain, gridtype=DGRID_NE)
 

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -799,7 +799,7 @@ contains
                                           isd, ied, jsd, jed, npz, &
                                           is,  ie,  js,  je,       &
                                           isd, ied, jsd, jed,      &
-                                          reg_bc_update_time )
+                                          reg_bc_update_time,1 )
          endif
 #endif
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -4314,7 +4314,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
                                          ,is,ie,js,je                 &
                                          ,isd,ied,jsd,jed             &
                                          ,fcst_time                   &
-                                         ,index4 )
+                                         ,it,index4 )
 !
 !---------------------------------------------------------------------
 !***  Select the given variable's boundary data at the two
@@ -4332,7 +4332,8 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
       integer,intent(in) :: lbnd_x,ubnd_x,lbnd_y,ubnd_y,ubnd_z           !<-- Dimensions of full prognostic array to be updated.
 !
       integer,intent(in) :: is,ie,js,je                               &  !<-- Compute limits
-                           ,isd,ied,jsd,jed                              !<-- Memory limits
+                           ,isd,ied,jsd,jed                           &  !<-- Memory limits
+                           ,it                                           !<-- Acoustic step 
 !
       integer,intent(in),optional :: index4                              !<-- Index for the 4-D tracer array.
 !
@@ -4588,7 +4589,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
                                     ,fcst_time                           &
                                     ,bc_update_interval                  &
                                     ,i1_blend,i2_blend,j1_blend,j2_blend &
-                                    ,i_bc,j_bc,nside,bc_vbl_name,blend )
+                                    ,i_bc,j_bc,nside,bc_vbl_name,blend,it )
         endif
 !
 !---------------------------------------------------------------------
@@ -4718,7 +4719,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
                                       ,fcst_time                           &
                                       ,bc_update_interval                  &
                                       ,i1_blend,i2_blend,j1_blend,j2_blend &
-                                      ,i_bc,j_bc,nside,bc_vbl_name,blend )
+                                      ,i_bc,j_bc,nside,bc_vbl_name,blend,it )
 
 !---------------------------------------------------------------------
 !***  Update the boundary region of the input array at the given
@@ -4743,7 +4744,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
       integer,intent(in) :: is,ie,js,je                                  !<-- Min/Max index limits on task's computational subdomain
 !
-      integer,intent(in) :: bc_update_interval                           !<-- Time (hours) between BC data states
+      integer,intent(in) :: bc_update_interval,it                           !<-- Time (hours) between BC data states, acoustic step
 !
       real,intent(in) :: fcst_time                                       !<-- Current forecast time (sec)
 !
@@ -4780,6 +4781,19 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
       fraction_interval=mod(fcst_time,(bc_update_interval*3600.))     &
                        /(bc_update_interval*3600.)
+
+!---------------------------------------------------------------------
+!***  Special check for final acoustic step prior to new boundary information
+!***  being ingested.
+!---------------------------------------------------------------------
+
+       if (fraction_interval .eq. 0.0 .and. it .gt. 1) then
+        fraction_interval=1.0
+        if (is_master()) then
+         write(0,*) 'reset of fraction_interval ', trim(bc_vbl_name),it, fcst_time
+        endif
+       endif
+
 !
 !---------------------------------------------------------------------
 !

--- a/model/fv_tracer2d.F90
+++ b/model/fv_tracer2d.F90
@@ -764,7 +764,7 @@ subroutine tracer_2d_nested(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, np
                                                is,  ie,  js,  je,       &
                                                isd, ied, jsd, jed,      &
                                                reg_bc_update_time,      &
-                                               iq )
+                                               it, iq )
             enddo
       endif
 


### PR DESCRIPTION
**Description**

Makes a change in regional lateral boundary condition (LBC) processing to prevent an unintended scenario that leads to the temporary usage of older wind values along the boundary immediately before fresh LBC information is ingested.  This change smooths out a transient spike in domain-averaged surface pressure tendency values seen at the frequency of LBC updates.

Fixes #(issue #169)

**How Has This Been Tested?**

The fix was initially tested using a canned UFS Short Range Weather App case (which with 6 h LBC updates was very sensitive to the problem being solved).  More recent testing was made using various UFS regression tests in the context of the latest UFS code.  The hafs_regional_atm test was the most scrutinized, as it was one of the few regional regression tests with both nrows_blend > 0 and a multi-hour LBC update frequency.   

The proposed fix changes answers for regional tests, but not for global tests.   All of the testing thus far has been made with Intel compiled code on various WCOSS platforms (WCOSS-cray, WCOSS-dellp3, WCOSS2). 

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
