### PR TITLE
Rename CCPP_interstitial (to GFDL_interstitial?)

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -282,7 +282,7 @@ contains
    use ccpp_static_api,   only: ccpp_physics_init
    use CCPP_data,         only: ccpp_suite,          &
                                 cdata => cdata_tile, &
-                                CCPP_interstitial
+                                GFDL_interstitial
 #ifdef OPENMP
    use omp_lib
 #endif
@@ -491,7 +491,7 @@ contains
 #endif
    ! Create interstitial data type for fast physics; for multi-gases physics,
    ! pass q(:,:,:,1:num_gas) as qvi, otherwise pass q(:,:,:,1:1) as 4D array
-   call CCPP_interstitial%create(Atm(mygrid)%bd%is, Atm(mygrid)%bd%ie, Atm(mygrid)%bd%isd, Atm(mygrid)%bd%ied, &
+   call GFDL_interstitial%create(Atm(mygrid)%bd%is, Atm(mygrid)%bd%ie, Atm(mygrid)%bd%isd, Atm(mygrid)%bd%ied, &
                                  Atm(mygrid)%bd%js, Atm(mygrid)%bd%je, Atm(mygrid)%bd%jsd, Atm(mygrid)%bd%jed, &
                                  Atm(mygrid)%npz, Atm(mygrid)%ng,                                              &
                                  dt_atmos, p_split, Atm(mygrid)%flagstruct%k_split,                            &

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -194,7 +194,7 @@ contains
                                  ccpp_physics_timestep_finalize
     use CCPP_data,         only: ccpp_suite
     use CCPP_data,         only: cdata => cdata_tile
-    use CCPP_data,         only: CCPP_interstitial
+    use CCPP_data,         only: GFDL_interstitial
 
     use molecular_diffusion_mod, only: md_time, md_wait_sec, md_tadj_layers,          &
                                        thermosphere_adjustment
@@ -299,11 +299,11 @@ contains
       real :: time_total
       integer :: seconds, days
 
-      ccpp_associate: associate( cappa     => CCPP_interstitial%cappa,     &
-                                 dp1       => CCPP_interstitial%te0,       &
-                                 dtdt_m    => CCPP_interstitial%dtdt,      &
-                                 last_step => CCPP_interstitial%last_step, &
-                                 te_2d     => CCPP_interstitial%te0_2d     )
+      ccpp_associate: associate( cappa     => GFDL_interstitial%cappa,     &
+                                 dp1       => GFDL_interstitial%te0,       &
+                                 dtdt_m    => GFDL_interstitial%dtdt,      &
+                                 last_step => GFDL_interstitial%last_step, &
+                                 te_2d     => GFDL_interstitial%te0_2d     )
 
       is  = bd%is
       ie  = bd%ie
@@ -329,9 +329,9 @@ contains
       call ccpp_physics_timestep_init(cdata, suite_name=trim(ccpp_suite), group_name="fast_physics", ierr=ierr)
       ! Reset all interstitial variables for CCPP version
       ! of fast physics, and manually set runtime parameters
-      call CCPP_interstitial%reset()
+      call GFDL_interstitial%reset()
       if (flagstruct%do_sat_adj) then
-         CCPP_interstitial%out_dt = (idiag%id_mdt > 0)
+         GFDL_interstitial%out_dt = (idiag%id_mdt > 0)
       end if
 
 #ifdef MULTI_GASES

--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -61,7 +61,7 @@ module fv_mapz_mod
 !   </tr>
 !   <tr>
 !     <td>CCPP_data</td>
-!     <td>ccpp_suite, cdata_tile, CCPP_interstitial</td>
+!     <td>ccpp_suite, cdata_tile, GFDL_interstitial</td>
 !   </tr>
 !   <tr>
 !     <td>fv_timing_mod</td>
@@ -99,7 +99,7 @@ module fv_mapz_mod
   use ccpp_static_api,   only: ccpp_physics_run
   use CCPP_data,         only: ccpp_suite
   use CCPP_data,         only: cdata => cdata_tile
-  use CCPP_data,         only: CCPP_interstitial
+  use CCPP_data,         only: GFDL_interstitial
 #ifdef MULTI_GASES
   use multi_gases_mod,  only:  virq, virqd, vicpqd, vicvqd, num_gas
 #endif
@@ -229,8 +229,8 @@ contains
   integer:: nt, liq_wat, ice_wat, rainwat, snowwat, cld_amt, graupel, hailwat, ccn_cm3, iq, n, kmp, kp, k_next
   integer :: ierr
 
-      ccpp_associate: associate( fast_mp_consv => CCPP_interstitial%fast_mp_consv, &
-                                 kmp           => CCPP_interstitial%kmp            )
+      ccpp_associate: associate( fast_mp_consv => GFDL_interstitial%fast_mp_consv, &
+                                 kmp           => GFDL_interstitial%kmp            )
 
        k1k = rdgas/cv_air   ! akap / (1.-akap) = rg/Cv=0.4
         rg = rdgas
@@ -673,7 +673,7 @@ contains
 !$OMP                               ng,gridstruct,E_Flux,pdt,dtmp,reproduce_sum,q,             &
 !$OMP                               mdt,cld_amt,cappa,dtdt,out_dt,rrg,akap,do_sat_adj,         &
 !$OMP                               kord_tm,pe4, npx,npy,ccn_cm3,u_dt,v_dt, c2l_ord,bd,dp0,ps, &
-!$OMP                                cdata,CCPP_interstitial)                           &
+!$OMP                                cdata,GFDL_interstitial)                           &
 !$OMP                        shared(ccpp_suite)                                                &
 #ifdef MULTI_GASES
 !$OMP                        shared(num_gas)                                                   &
@@ -688,7 +688,7 @@ contains
 !$OMP                               ng,gridstruct,E_Flux,pdt,dtmp,reproduce_sum,q,             &
 !$OMP                               mdt,cld_amt,cappa,dtdt,out_dt,rrg,akap,do_sat_adj,         &
 !$OMP                               fast_mp_consv,kord_tm, pe4,npx,npy, ccn_cm3,               &
-!$OMP                               u_dt,v_dt,c2l_ord,bd,dp0,ps,cdata,CCPP_interstitial)        &
+!$OMP                               u_dt,v_dt,c2l_ord,bd,dp0,ps,cdata,GFDL_interstitial)        &
 !$OMP                        shared(ccpp_suite)                                                &
 #ifdef MULTI_GASES
 !$OMP                        shared(num_gas)                                                   &


### PR DESCRIPTION
**Description**

I would like to rename `CCPP_interstitial` into something more meaningful for the fv3atm atmospheric model. The term is confusing, because fv3atm has `GFS_interstitial` for the GFS (slow/traditional physics), and `CCPP_interstitial` for the FV3 dycore (fast/tightly coupled physics). Both of them are interstitial data types required by CCPP and they are defined in a module called `CCPP_typedefs.F90`.

For now, I changed it to `GFDL_interstitial` but I am not 100% happy with this name and I would welcome suggestions for a better name. This PR shows the small extent of these changes.

Related, I would like to consider renaming the CCPP variable `cdata_tile` to something more meaningful, for example `cdata_dycore`? There are two other `cdata` variables in fv3atm, `cdata_block` (when blocked data is passed) and `cdata_domain` (when all blocks are passed as one contiguous data).

Fixes https://github.com/NOAA-EMC/fv3atm/issues/507.

**How Has This Been Tested?**

Tested with the ufs-weather-model regression tests, see https://github.com/ufs-community/ufs-weather-model/pull/1130

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
