### PR TITLE
32-bit physics with FV3_RAP

### DIFF
--- a/model/fv_fill.F90
+++ b/model/fv_fill.F90
@@ -37,7 +37,7 @@ module fv_fill_mod
 ! </table>
 
    use mpp_domains_mod,     only: mpp_update_domains, domain2D
-   use platform_mod,        only: kind_phys => r8_kind
+   use GFS_typedefs,        only: kind_phys
 
    implicit none
    public fillz


### PR DESCRIPTION
This is an attempt to get 32-bit physics working with the FV3_RAP suite, based on work done by NRL on the Neptune model. Presently, it fails during initialization. I've reached the limits of my knowledge of FV3 initialization and need help from other developers to finish this. See the ufs-weather-model PR for a test case. FIXME: Link to ufs-weather-model PR.