### PR TITLE
Regional decomposition test fix (when nrows_blend > 0)

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -265,7 +265,7 @@ character(len=20)   :: mod_name = 'fvGFS/atmosphere_mod'
   logical :: cold_start = .false.     !  used in initial condition
 
   integer, dimension(:), allocatable :: id_tracerdt_dyn
-  integer :: sphum, liq_wat, rainwat, ice_wat, snowwat, graupel, cld_amt  ! condensate species tracer indices
+  integer :: sphum, liq_wat, rainwat, ice_wat, snowwat, graupel, hailwat, cld_amt  ! condensate species tracer indices
 
   integer :: mygrid = 1
   integer :: p_split = 1
@@ -403,9 +403,10 @@ contains
    rainwat = get_tracer_index (MODEL_ATMOS, 'rainwat' )
    snowwat = get_tracer_index (MODEL_ATMOS, 'snowwat' )
    graupel = get_tracer_index (MODEL_ATMOS, 'graupel' )
+   hailwat = get_tracer_index (MODEL_ATMOS, 'hailwat' )
    cld_amt = get_tracer_index (MODEL_ATMOS, 'cld_amt')
 
-   if (max(sphum,liq_wat,ice_wat,rainwat,snowwat,graupel) > Atm(mygrid)%flagstruct%nwat) then
+   if (max(sphum,liq_wat,ice_wat,rainwat,snowwat,graupel,hailwat) > Atm(mygrid)%flagstruct%nwat) then
       call mpp_error (FATAL,' atmosphere_init: condensate species are not first in the list of &
                             &tracers defined in the field_table')
    endif

--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -1248,7 +1248,8 @@ contains
 
                                                      call timing_on('COMM_TOTAL')
 #ifndef ROT3
-    if ( it/=n_split)   &
+!    if ( it/=n_split)   &
+    if ( .not. flagstruct%regional .and. it/=n_split)   &
          call start_group_halo_update(i_pack(8), u, v, domain, gridtype=DGRID_NE)
 #endif
                                                      call timing_off('COMM_TOTAL')
@@ -1351,7 +1352,11 @@ contains
                                        isd, ied, jsd, jed,      &
                                        reg_bc_update_time,it )
 
-         call mpp_update_domains(u, v, domain, gridtype=DGRID_NE)
+!         call mpp_update_domains(u, v, domain, gridtype=DGRID_NE)
+#ifndef ROT3
+         if (it/=n_split)   &
+            call start_group_halo_update(i_pack(8), u, v, domain, gridtype=DGRID_NE)
+#endif
 
     endif
 

--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -1248,7 +1248,6 @@ contains
 
                                                      call timing_on('COMM_TOTAL')
 #ifndef ROT3
-!    if ( it/=n_split)   &
     if ( .not. flagstruct%regional .and. it/=n_split)   &
          call start_group_halo_update(i_pack(8), u, v, domain, gridtype=DGRID_NE)
 #endif
@@ -1352,7 +1351,6 @@ contains
                                        isd, ied, jsd, jed,      &
                                        reg_bc_update_time,it )
 
-!         call mpp_update_domains(u, v, domain, gridtype=DGRID_NE)
 #ifndef ROT3
          if (it/=n_split)   &
             call start_group_halo_update(i_pack(8), u, v, domain, gridtype=DGRID_NE)

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -4513,17 +4513,9 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
               endif
             endif
 !
+! Note: Original code checked for corner region and avoided overlap, but changed this to blend corners from both boundaries
              i1_blend=is
              i2_blend=is+nrows_blend_user-1
-! Original code avoided overlap, but changed this to blend corners from both boundaries
-!             j1_blend=js
-!             j2_blend=je
-!             if(north_bc)then
-!               j1_blend=js+nrows_blend_user     !<-- North BC already handles nrows_blend_user blending rows
-!             endif
-!             if(south_bc)then
-!               j2_blend=je-nrows_blend_user     !<-- South BC already handles nrows_blend_user blending rows
-!             endif
 
             IF ( north_bc ) THEN
             j1_blend=js
@@ -4581,17 +4573,9 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
               endif
             endif
 !
+! Note: Original code checked for corner region and avoided overlap, but changed this to blend corners from both boundaries
             i1_blend=i1-nrows_blend_user
             i2_blend=i1-1
-! Original code avoided overlap, but changed this to blend corners from both boundaries
-!             j1_blend=js
-!             j2_blend=je
-!             if(north_bc)then
-!               j1_blend=js+nrows_blend_user   !<-- North BC already handled nrows_blend_user blending rows.
-!             endif
-!             if(south_bc)then
-!               j2_blend=je-nrows_blend_user   !<-- South BC already handled nrows_blend_user blending rows.
-!             endif
 
             IF ( north_bc ) THEN
             j1_blend=js

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -4515,6 +4515,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
              i1_blend=is
              i2_blend=is+nrows_blend_user-1
+! Original code avoided overlap, but changed this to blend corners from both boundaries
 !             j1_blend=js
 !             j2_blend=je
 !             if(north_bc)then
@@ -4582,6 +4583,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !
             i1_blend=i1-nrows_blend_user
             i2_blend=i1-1
+! Original code avoided overlap, but changed this to blend corners from both boundaries
 !             j1_blend=js
 !             j2_blend=je
 !             if(north_bc)then

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -410,6 +410,17 @@ contains
       else
         nrows_blend=nrows_blend_in_data                                    !<-- # of blending rows in the BC files.
       endif
+      
+      IF ( north_bc .or. south_bc ) THEN
+        IF ( nrows_blend_user > jed - nhalo_model - (jsd + nhalo_model) + 1 ) THEN
+        call mpp_error(FATAL,'Number of blending rows is greater than the north-south tile size!')
+        ENDIF
+      ENDIF
+      IF ( west_bc .or. east_bc ) THEN
+        IF ( nrows_blend_user > ied - nhalo_model - (isd + nhalo_model) + 1 ) THEN
+        call mpp_error(FATAL,'Number of blending rows is greater than the east-west tile size!')
+        ENDIF
+      ENDIF
 !
       call check(nf90_close(ncid))                                         !<-- Close the BC file for now.
 !
@@ -4606,7 +4617,6 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !---------------------------------------------------------------------
 !
 
-        blend = blend .and. ( .not. (  (trim(bc_vbl_name)=='u') .or. (trim(bc_vbl_name)=='v') ) ) ! OK
 
         if(call_interp)then
 !
@@ -4863,7 +4873,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !-----------
 !
       if(nside==1.and.north_bc)then
-        rdenom=1./real(j2_blend-j_bc-1)
+        rdenom=1./real(Max(1,j2_blend-j_bc-1))
         do k=1,ubnd_z
           do j=j1_blend,j2_blend
             factor_dist=exp(-(blend_exp1+blend_exp2*(j-j_bc-1)*rdenom)) !<-- Exponential falloff of blending weights.
@@ -4882,7 +4892,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !-----------
 !
       if(nside==2.and.south_bc)then
-        rdenom=1./real(j_bc-j1_blend-1)
+        rdenom=1./real(Max(1,j_bc-j1_blend-1))
         do k=1,ubnd_z
           do j=j1_blend,j2_blend
             factor_dist=exp(-(blend_exp1+blend_exp2*(j_bc-j-1)*rdenom)) !<-- Exponential falloff of blending weights.
@@ -4900,7 +4910,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !----------
 !
       if(nside==3.and.east_bc)then
-        rdenom=1./real(i2_blend-i_bc-1)
+        rdenom=1./real(Max(1,i2_blend-i_bc-1))
         do k=1,ubnd_z
           do j=j1_blend,j2_blend
             do i=i1_blend,i2_blend
@@ -4921,7 +4931,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !----------
 !
       if(nside==4.and.west_bc)then
-        rdenom=1./real(i_bc-i1_blend-1)
+        rdenom=1./real(Max(1, i_bc-i1_blend-1))
         do k=1,ubnd_z
           do j=j1_blend,j2_blend
             do i=i1_blend,i2_blend

--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -404,10 +404,16 @@ contains
             qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)
          enddo
       enddo
-   else
+   elseif ( nwat==6 ) then
       do k=1,kbot
          do i=is,ie
             qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)+q0(i,k,graupel)
+         enddo
+      enddo
+   elseif ( nwat==7 ) then
+      do k=1,kbot
+         do i=is,ie
+            qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)+q0(i,k,graupel)+q0(i,k,hailwat)
          enddo
       enddo
    endif
@@ -985,10 +991,16 @@ contains
          do i=is,ie
             qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)
          enddo
-   else
+   elseif ( nwat==6 ) then
       do k=1,kbot
          do i=is,ie
             qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)+q0(i,k,graupel)
+         enddo
+      enddo
+   elseif ( nwat==7 ) then
+      do k=1,kbot
+         do i=is,ie
+            qcon(i,k) = q0(i,k,liq_wat)+q0(i,k,ice_wat)+q0(i,k,snowwat)+q0(i,k,rainwat)+q0(i,k,graupel)+q0(i,k,hailwat)
          enddo
       enddo
    endif


### PR DESCRIPTION
**Description**

Fixes failure of decomposition test for regional case with nrows_blend > 0. Also fixes a bug where nrows_blend=1 caused a crash. Credit to @junwang-noaa for fix in dyn_core.F90
Incidental (unrelated) fix in driver/fvGFS/atmosphere.F90 and fv_sg.F90 to add check for value of hailwat (nwat = 7)

Fixes dcp test failure that was raised in https://github.com/ufs-community/ufs-weather-model/pull/1158

**How Has This Been Tested?**

Tested on hera with
./opnReqTest.ted -n regional_3km -c dcp -ek
(requires a change to tests/opnReqTests/dcp.sh)

See: https://github.com/MicroTed/ufs-weather-model.git, branch: regional_blend_fix

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
