### PR TITLE
Expose remap_scalar and remap_dwinds to fv3-jedi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ endif()
 
 if(NOT FMS_FOUND)
   find_package(FMS REQUIRED COMPONENTS ${kind})
-  add_library(fms ALIAS FMS::fms_${kind})
+  string(TOLOWER ${kind} kind_lower)
+  add_library(fms ALIAS FMS::fms_${kind_lower})
 endif()
 
 list(APPEND moving_srcs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ set_property(SOURCE model/fv_mapz.F90  APPEND_STRING PROPERTY COMPILE_FLAGS "${F
 set_property(SOURCE tools/fv_diagnostics.F90  APPEND_STRING PROPERTY COMPILE_FLAGS "-O0")
 
 set_target_properties(fv3 PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/fv3)
-target_include_directories(fv3 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/fv3>
+target_include_directories(fv3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/fv3>
                                          $<INSTALL_INTERFACE:include/fv3>)
 
 target_include_directories(fv3 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -202,7 +202,7 @@ module external_ic_mod
 ! Include variable "version" to be written to log file.
 #include<file_version.h>
 
-   public get_external_ic, get_cubed_sphere_terrain, remap_scalar, remap_dwinds, source
+   public get_external_ic, get_cubed_sphere_terrain, remap_scalar, remap_dwinds
 
 contains
 

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -202,7 +202,7 @@ module external_ic_mod
 ! Include variable "version" to be written to log file.
 #include<file_version.h>
 
-   public get_external_ic, get_cubed_sphere_terrain
+   public get_external_ic, get_cubed_sphere_terrain, remap_scalar, remap_dwinds, source
 
 contains
 

--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -394,7 +394,7 @@ contains
     Atm(1)%Fv_restart_is_open = open_file(Atm(1)%Fv_restart,fname,"read", is_restart=.true., pelist=pes)
     if (Atm(1)%Fv_restart_is_open) then
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Fv_restart)
+      call read_restart(Atm(1)%Fv_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
       call close_file(Atm(1)%Fv_restart)
       Atm(1)%Fv_restart_is_open = .false.
     endif
@@ -419,7 +419,7 @@ contains
     Atm(1)%Fv_restart_tile_is_open = open_file(Atm(1)%Fv_restart_tile, fname, "read", fv_domain, is_restart=.true.)
     if (Atm(1)%Fv_restart_tile_is_open) then
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Fv_restart_tile)
+      call read_restart(Atm(1)%Fv_restart_tile, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
       call close_file(Atm(1)%Fv_restart_tile)
       Atm(1)%Fv_restart_tile_is_open = .false.
     endif
@@ -429,7 +429,7 @@ contains
     Atm(1)%Tra_restart_is_open = open_file(Atm(1)%Tra_restart, fname, "read", fv_domain, is_restart=.true.)
     if (Atm(1)%Tra_restart_is_open) then
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Tra_restart)
+      call read_restart(Atm(1)%Tra_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
       call close_file(Atm(1)%Tra_restart)
       Atm(1)%Tra_restart_is_open = .false.
     else
@@ -442,7 +442,7 @@ contains
     if (Atm(1)%Rsf_restart_is_open) then
       Atm(1)%flagstruct%srf_init = .true.
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Rsf_restart)
+      call read_restart(Atm(1)%Rsf_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
       call close_file(Atm(1)%Rsf_restart)
       Atm(1)%Rsf_restart_is_open = .false.
     else
@@ -456,7 +456,7 @@ contains
          Atm(1)%Mg_restart_is_open = open_file(Atm(1)%Mg_restart, fname, "read", fv_domain, is_restart=.true.)
          if (Atm(1)%Mg_restart_is_open) then
            call fv_io_register_restart(Atm(1))
-           call read_restart(Atm(1)%Mg_restart)
+           call read_restart(Atm(1)%Mg_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
            call close_file(Atm(1)%Mg_restart)
            Atm(1)%Mg_restart_is_open = .false.
          else
@@ -467,7 +467,7 @@ contains
          Atm(1)%Lnd_restart_is_open = open_file(Atm(1)%Lnd_restart, fname, "read", fv_domain, is_restart=.true.)
          if (Atm(1)%Lnd_restart_is_open) then
            call fv_io_register_restart(Atm(1))
-           call read_restart(Atm(1)%Lnd_restart)
+           call read_restart(Atm(1)%Lnd_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
            call close_file(Atm(1)%Lnd_restart)
            Atm(1)%Lnd_restart_is_open = .false.
          else
@@ -640,7 +640,7 @@ contains
        if (Atm(1)%Rsf_restart_is_open) then
           Atm%flagstruct%srf_init = .true.
           call fv_io_register_restart(Atm(1))
-          call read_restart(Atm(1)%Rsf_restart)
+          call read_restart(Atm(1)%Rsf_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
           call close_file(Atm(1)%Rsf_restart)
           Atm(1)%Rsf_restart_is_open = .false.
          call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')
@@ -1279,12 +1279,12 @@ contains
     call fv_io_register_restart_BCs(Atm)
 
     if (Atm%neststruct%BCfile_sw_is_open) then
-      call read_restart_bc(Atm%neststruct%BCfile_sw)
+      call read_restart_bc(Atm%neststruct%BCfile_sw, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
       call close_file(Atm%neststruct%BCfile_sw)
     endif
 
     if (Atm%neststruct%BCfile_ne_is_open) then
-     call read_restart_bc(Atm%neststruct%BCfile_ne) 
+     call read_restart_bc(Atm%neststruct%BCfile_ne, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum) 
      call close_file(Atm%neststruct%BCfile_ne)
     endif
 

--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -419,7 +419,7 @@ contains
     Atm(1)%Fv_restart_tile_is_open = open_file(Atm(1)%Fv_restart_tile, fname, "read", fv_domain, is_restart=.true.)
     if (Atm(1)%Fv_restart_tile_is_open) then
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Fv_restart_tile, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+      call read_restart(Atm(1)%Fv_restart_tile)
       call close_file(Atm(1)%Fv_restart_tile)
       Atm(1)%Fv_restart_tile_is_open = .false.
     endif
@@ -429,7 +429,7 @@ contains
     Atm(1)%Tra_restart_is_open = open_file(Atm(1)%Tra_restart, fname, "read", fv_domain, is_restart=.true.)
     if (Atm(1)%Tra_restart_is_open) then
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Tra_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+      call read_restart(Atm(1)%Tra_restart)
       call close_file(Atm(1)%Tra_restart)
       Atm(1)%Tra_restart_is_open = .false.
     else
@@ -442,7 +442,7 @@ contains
     if (Atm(1)%Rsf_restart_is_open) then
       Atm(1)%flagstruct%srf_init = .true.
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Rsf_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+      call read_restart(Atm(1)%Rsf_restart)
       call close_file(Atm(1)%Rsf_restart)
       Atm(1)%Rsf_restart_is_open = .false.
     else
@@ -456,7 +456,7 @@ contains
          Atm(1)%Mg_restart_is_open = open_file(Atm(1)%Mg_restart, fname, "read", fv_domain, is_restart=.true.)
          if (Atm(1)%Mg_restart_is_open) then
            call fv_io_register_restart(Atm(1))
-           call read_restart(Atm(1)%Mg_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+           call read_restart(Atm(1)%Mg_restart)
            call close_file(Atm(1)%Mg_restart)
            Atm(1)%Mg_restart_is_open = .false.
          else
@@ -467,7 +467,7 @@ contains
          Atm(1)%Lnd_restart_is_open = open_file(Atm(1)%Lnd_restart, fname, "read", fv_domain, is_restart=.true.)
          if (Atm(1)%Lnd_restart_is_open) then
            call fv_io_register_restart(Atm(1))
-           call read_restart(Atm(1)%Lnd_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+           call read_restart(Atm(1)%Lnd_restart)
            call close_file(Atm(1)%Lnd_restart)
            Atm(1)%Lnd_restart_is_open = .false.
          else
@@ -640,7 +640,7 @@ contains
        if (Atm(1)%Rsf_restart_is_open) then
           Atm%flagstruct%srf_init = .true.
           call fv_io_register_restart(Atm(1))
-          call read_restart(Atm(1)%Rsf_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+          call read_restart(Atm(1)%Rsf_restart)
           call close_file(Atm(1)%Rsf_restart)
           Atm(1)%Rsf_restart_is_open = .false.
          call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')
@@ -1279,12 +1279,12 @@ contains
     call fv_io_register_restart_BCs(Atm)
 
     if (Atm%neststruct%BCfile_sw_is_open) then
-      call read_restart_bc(Atm%neststruct%BCfile_sw, ignore_checksum=Atm%flagstruct%ignore_rst_cksum)
+      call read_restart_bc(Atm%neststruct%BCfile_sw)
       call close_file(Atm%neststruct%BCfile_sw)
     endif
 
     if (Atm%neststruct%BCfile_ne_is_open) then
-     call read_restart_bc(Atm%neststruct%BCfile_ne, ignore_checksum=Atm%flagstruct%ignore_rst_cksum)
+     call read_restart_bc(Atm%neststruct%BCfile_ne) 
      call close_file(Atm%neststruct%BCfile_ne)
     endif
 

--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -394,7 +394,7 @@ contains
     Atm(1)%Fv_restart_is_open = open_file(Atm(1)%Fv_restart,fname,"read", is_restart=.true., pelist=pes)
     if (Atm(1)%Fv_restart_is_open) then
       call fv_io_register_restart(Atm(1))
-      call read_restart(Atm(1)%Fv_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+      call read_restart(Atm(1)%Fv_restart)
       call close_file(Atm(1)%Fv_restart)
       Atm(1)%Fv_restart_is_open = .false.
     endif
@@ -1279,12 +1279,12 @@ contains
     call fv_io_register_restart_BCs(Atm)
 
     if (Atm%neststruct%BCfile_sw_is_open) then
-      call read_restart_bc(Atm%neststruct%BCfile_sw, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
+      call read_restart_bc(Atm%neststruct%BCfile_sw, ignore_checksum=Atm%flagstruct%ignore_rst_cksum)
       call close_file(Atm%neststruct%BCfile_sw)
     endif
 
     if (Atm%neststruct%BCfile_ne_is_open) then
-     call read_restart_bc(Atm%neststruct%BCfile_ne, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum) 
+     call read_restart_bc(Atm%neststruct%BCfile_ne, ignore_checksum=Atm%flagstruct%ignore_rst_cksum)
      call close_file(Atm%neststruct%BCfile_ne)
     endif
 


### PR DESCRIPTION
The routines remap_dwinds and remap_scalar are needed by fv3-jedi, which requires them to be made public in atmos_cubed_sphere. The changes to the CMakeLists.txt file allow the routines to be linked correctly.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
