### PR TITLE
FMS library not found in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ endif()
 
 if(NOT FMS_FOUND)
   find_package(FMS REQUIRED COMPONENTS ${kind})
-  add_library(fms ALIAS FMS::fms_${kind})
+  string(TOLOWER ${kind} kind_lower)
+  add_library(fms ALIAS FMS::fms_${kind_lower})
 endif()
 
 list(APPEND moving_srcs


### PR DESCRIPTION
**Description**

Fixes #201 

**How Has This Been Tested?**
Since the FV3 dycore is not built as a standalone, this cannot be tested to completion.
However, the `cmake` configuration now succeeds instead of failing trying to resolve the FMS dependency.

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
