### PR TITLE
Implementing CI

### DIFF
--- a/.github/workflows/SHiELD_parallelworks.yml
+++ b/.github/workflows/SHiELD_parallelworks.yml
@@ -1,0 +1,45 @@
+name: Compile SHiELD SOLO and run tests
+
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  buildstep:
+    runs-on: [self-hosted]
+    name: SOLO SHiELD build
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        runpath: [/pw/storage/PWscripts]
+        runscript: [FV3checkoutStartClusters.py, FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
+    steps:
+      - env:
+          RUNPATH: ${{ matrix.runpath }}
+          RUNSCRIPT: ${{ matrix.runscript }}
+        run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
+        
+  tests:
+    runs-on: [self-hosted]
+    name: SOLO SHiELD test suite
+    needs: [buildstep]
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        runpath: [/pw/storage/PWscripts]
+        runscript: [FV3C128r20.solo.superCStartClusters.py]
+    steps:
+      - env:
+          RUNPATH: ${{ matrix.runpath }}
+          RUNSCRIPT: ${{ matrix.runscript }}
+        run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
+        
+  shutdowncluster:
+    runs-on: [self-hosted]
+    name: Shutdown cluster
+    if: always()
+    needs: [buildstep, tests]
+    steps:
+      - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py ci_fv3

--- a/.github/workflows/SHiELD_parallelworks.yml
+++ b/.github/workflows/SHiELD_parallelworks.yml
@@ -5,25 +5,32 @@ on:
     branches:
       - main
 jobs:
-  buildstep:
+  checkout:
+    runs-on: [self-hosted]
+    name: Checkout Code
+    steps:
+    - run: python3 /pw/storage/PWscripts/FV3checkoutStartClusters.py $GITHUB_REF
+    
+  build:
     runs-on: [self-hosted]
     name: SOLO SHiELD build
+    needs: [checkout]
     strategy:
       fail-fast: true
-      max-parallel: 1
+      max-parallel: 3
       matrix:
         runpath: [/pw/storage/PWscripts]
-        runscript: [FV3checkoutStartClusters.py, FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
+        runscript: [FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
     steps:
       - env:
           RUNPATH: ${{ matrix.runpath }}
           RUNSCRIPT: ${{ matrix.runscript }}
         run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
         
-  tests:
+  test:
     runs-on: [self-hosted]
     name: SOLO SHiELD test suite
-    needs: [buildstep]
+    needs: [checkout, build]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -40,6 +47,6 @@ jobs:
     runs-on: [self-hosted]
     name: Shutdown cluster
     if: always()
-    needs: [buildstep, tests]
+    needs: [checkout, build, test]
     steps:
       - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py ci_fv3


### PR DESCRIPTION
**Description**
Parallelworks is currently down, so I will keep this as a draft until it comes back on. - This is resolved.

This PR brings in a github actions yaml file that uses a Self-Hosted Runner (Parallelworks rdhpcs cloud resources) to automatically compile solo shield and run idealized tests on Pull Requests to the main branch of the GFDL_atmos_cubed_sphere repository.  The actual scripts referenced in this yaml are stored on the Parallelworks resource.  The following is a description of how the CI works:

- The CI automatically triggers when anyone submits a PR to the main branch
- The CI consists of 3 stages:
 1. Build
 2. Test
 3. Shut down
- The Build stage has 4 steps:
 1. Checkout Code
 2. Build the sw solo shield configuration
 3. Build the nh solo shield configuration
 4. Build the hydro solo shield configuration
- The Test stage only contains one test in this initial release.  This stage will run a test and then compare restarts against a baseline.  The test will fail if the run fails or the restarts differ
- We are working to speed up these tests on the cloud (currently they are too slow to run all idealized tests)

**How Has This Been Tested?**

This has been tested with generating test PRs in my fork: 

https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere/pull/14 shows that when a PR targets a branch not named "main" the tests will not run

https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere/pull/15 shows that when a PR targets the main branch tests run 

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
(Relies on https://github.com/NOAA-GFDL/SHiELD_build/pull/13)
(Relies on https://github.com/NOAA-GFDL/SHiELD_build/pull/15)