### PR TITLE
CI Parallelworks update

### DIFF
--- a/.github/workflows/SHiELD_parallelworks.yml
+++ b/.github/workflows/SHiELD_parallelworks.yml
@@ -1,0 +1,45 @@
+name: Compile SHiELD SOLO and run tests
+
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  buildstep:
+    runs-on: [self-hosted]
+    name: SOLO SHiELD build
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        runpath: [/pw/storage/PWscripts]
+        runscript: [FV3checkoutStartClusters.py, FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
+    steps:
+      - env:
+          RUNPATH: ${{ matrix.runpath }}
+          RUNSCRIPT: ${{ matrix.runscript }}
+        run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
+        
+  tests:
+    runs-on: [self-hosted]
+    name: SOLO SHiELD test suite
+    needs: [buildstep]
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        runpath: [/pw/storage/PWscripts]
+        runscript: [FV3C128r20.solo.superCStartClusters.py]
+    steps:
+      - env:
+          RUNPATH: ${{ matrix.runpath }}
+          RUNSCRIPT: ${{ matrix.runscript }}
+        run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
+        
+  shutdowncluster:
+    runs-on: [self-hosted]
+    name: Shutdown cluster
+    if: always()
+    needs: [buildstep, tests]
+    steps:
+      - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py ci_fv3

--- a/.github/workflows/SHiELD_parallelworks.yml
+++ b/.github/workflows/SHiELD_parallelworks.yml
@@ -49,4 +49,4 @@ jobs:
     if: always()
     needs: [checkout, build, test]
     steps:
-      - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py ci_fv3
+      - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py cifv3

--- a/.github/workflows/SHiELD_parallelworks.yml
+++ b/.github/workflows/SHiELD_parallelworks.yml
@@ -5,25 +5,32 @@ on:
     branches:
       - main
 jobs:
-  buildstep:
+  checkout:
+    runs-on: [self-hosted]
+    name: Checkout Code
+    steps:
+    - run: python3 /pw/storage/PWscripts/FV3checkoutStartClusters.py $GITHUB_REF
+    
+  build:
     runs-on: [self-hosted]
     name: SOLO SHiELD build
+    needs: [checkout]
     strategy:
       fail-fast: true
-      max-parallel: 1
+      max-parallel: 3
       matrix:
         runpath: [/pw/storage/PWscripts]
-        runscript: [FV3checkoutStartClusters.py, FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
+        runscript: [FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
     steps:
       - env:
           RUNPATH: ${{ matrix.runpath }}
           RUNSCRIPT: ${{ matrix.runscript }}
         run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
         
-  tests:
+  test:
     runs-on: [self-hosted]
     name: SOLO SHiELD test suite
-    needs: [buildstep]
+    needs: [checkout, build]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -40,6 +47,6 @@ jobs:
     runs-on: [self-hosted]
     name: Shutdown cluster
     if: always()
-    needs: [buildstep, tests]
+    needs: [checkout, build, test]
     steps:
       - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py ci_fv3


### PR DESCRIPTION
**Description**

Parallelworks made a change yesterday causing all CI tests to fail due to an underscore in the cluster name "ci_fv3" I am removing the underscore to correct this issue.

Fixes # (issue)

**How Has This Been Tested?**

The CI passing on this PR is an appropriate test

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
