### PR TITLE
Fixes many issues in fv_regional_bc.F90 and allows debug & 2threads RRFS variants to pass

### DIFF
--- a/model/fv_fill.F90
+++ b/model/fv_fill.F90
@@ -37,7 +37,7 @@ module fv_fill_mod
 ! </table>
 
    use mpp_domains_mod,     only: mpp_update_domains, domain2D
-   use platform_mod,        only: kind_phys => r8_kind
+   use GFS_typedefs,        only: kind_phys
 
    implicit none
    public fillz

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -1914,11 +1914,10 @@ contains
 !
 !-----------------------------------------------------------------------
 !*** Whoever did this intentionally added a bug to the code and hid it,
-!*** to avoid fixing other bugs elsewhere.
-!*** The result is that RRFS debug mode was broken for a long time
-!*** and some boundary data was gibberish.
-!*** I'm retaining this code, commented out, as a reminder to others
-!*** of what NOT to do.
+!*** to conceal fixing other bugs elsewhere. This produced gibberish
+!*** initial surface pressure, and made it impossible to test RRFS in
+!*** debug mode for a long time. I'm retaining this code, commented out,
+!*** as a reminder to others of what NOT to do.
 !-----------------------------------------------------------------------
 !
         !ps_reg=-9999999 ! for now don't set to snan until remap dwinds is changed
@@ -3578,35 +3577,27 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !---------------------------------------------------------------------------------
 !
       if(side=='west')then
-        do j=jss,jes
+        do j=jsv,jev
           psc(isv,j) = psc(iss,j)
         enddo
-        psc(iev,jsv) = psc(ies,jss)
-        psc(iev,jev) = psc(ies,jes)
       endif
 !
       if(side=='east')then
-        do j=jss,jes
+        do j=jsv,jev
           psc(iev,j) = psc(ies,j)
         enddo
-        psc(iev,jev) = psc(ies,jes)
-        psc(iev,jev) = psc(ies,jes)
       endif
 !
       if(side=='south')then
-        do i=iss,ies
+        do i=isv,iev
           psc(i,jsv) = psc(i,jss)
         enddo
-        psc(isv,jsv) = psc(iss,jss)
-        psc(iev,jsv) = psc(ies,jss)
       endif
 !
       if(side=='north')then
-        do i=iss,ies
+        do i=isv,iev
           psc(i,jev) = psc(i,jes)
         enddo
-        psc(isv,jev) = psc(iss,jes)
-        psc(iev,jev) = psc(ies,jes)
       endif
 !
       is = iss
@@ -3672,35 +3663,27 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !---------------------------------------------------------------------------------
 !
       if(side=='west')then
-        do j=jss,jes
+        do j=jsv,jev
           ps(isv,j) = ps(iss,j)
         enddo
-        ps(iev,jsv) = ps(ies,jss)
-        ps(iev,jev) = ps(ies,jes)
       endif
 !
       if(side=='east')then
-        do j=jss,jes
+        do j=jsv,jev
           ps(iev,j) = ps(ies,j)
         enddo
-        ps(iev,jev) = ps(ies,jes)
-        ps(iev,jev) = ps(ies,jes)
       endif
 !
       if(side=='south')then
-        do i=iss,ies
+        do i=isv,iev
           ps(i,jsv) = ps(i,jss)
         enddo
-        ps(isv,jsv) = ps(iss,jss)
-        ps(iev,jsv) = ps(ies,jss)
       endif
 !
       if(side=='north')then
-        do i=iss,ies
+        do i=isv,iev
           ps(i,jev) = ps(i,jes)
         enddo
-        ps(isv,jev) = ps(iss,jes)
-        ps(iev,jev) = ps(ies,jes)
       endif
 
 !---------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**

Initializes ps_reg to real_snan (signalling NaN) and corrects all issues that come along later. This allows the RRFS 13km conus domain regression tests to run in debug and 2threads mode. It should fix gibberish boundary conditions and dubious initial surface pressures seen throughout the domain when boundary conditions are enabled.

I'd like to stress that the reason this PR is needed, is that a developer hid these bugs by initializing surface pressure ("ps_reg" in fv_regional_bc.F90) to -9999999 instead of debugging and fixing their code. That -9999999 propagates throughout fv_regional_bc.F90 and elsewhere in the model, adversely affecting many things. (See #215 for details.) Although this allows the model to run without crashing when debug mode is disabled, it harms the forecast in many ways. It also prevented us from testing the RRFS in debug mode for a long time.

Fixes #213
Fixes #214 
Fixes #215

This is a workaround for #212, but it is NOT a fix. The bad boundary files have to be fixed in the program that generates those files.

**How Has This Been Tested?**

Hera and Jet intel tests of the RRFS conus 13km domain in debug mode.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no changes needed to documentation)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (no dependencies)
