### PR TITLE
Fix several bugs in fv_regional_bc.F90 relating to uninitialized or incorrectly initialized memory.

### DIFF
--- a/model/fv_fill.F90
+++ b/model/fv_fill.F90
@@ -37,7 +37,7 @@ module fv_fill_mod
 ! </table>
 
    use mpp_domains_mod,     only: mpp_update_domains, domain2D
-   use platform_mod,        only: kind_phys => r8_kind
+   use GFS_typedefs,        only: kind_phys
 
    implicit none
    public fillz

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -1980,16 +1980,6 @@ contains
         allocate(ps_reg(is_input:ie_input,js_input:je_input))              !<-- Sfc pressure in domain's boundary region derived from BC files
 !
 !-----------------------------------------------------------------------
-!*** Whoever did this intentionally added a bug to the code and hid it,
-!*** to conceal fixing other bugs elsewhere. This produced gibberish
-!*** initial surface pressure, and made it impossible to test RRFS in
-!*** debug mode for a long time. I'm retaining this code, commented out,
-!*** as a reminder to others of what NOT to do.
-!-----------------------------------------------------------------------
-!
-        !ps_reg=-9999999 ! for now don't set to snan until remap dwinds is changed
-!
-!-----------------------------------------------------------------------
 !*** Initialize ps_reg to real_snan to detect errors later in code.
 !-----------------------------------------------------------------------
 !

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -1914,11 +1914,10 @@ contains
 !
 !-----------------------------------------------------------------------
 !*** Whoever did this intentionally added a bug to the code and hid it,
-!*** to avoid fixing other bugs elsewhere.
-!*** The result is that RRFS debug mode was broken for a long time
-!*** and some boundary data was gibberish.
-!*** I'm retaining this code, commented out, as a reminder to others
-!*** of what NOT to do.
+!*** to conceal fixing other bugs elsewhere. This produced gibberish
+!*** initial surface pressure, and made it impossible to test RRFS in
+!*** debug mode for a long time. I'm retaining this code, commented out,
+!*** as a reminder to others of what NOT to do.
 !-----------------------------------------------------------------------
 !
         !ps_reg=-9999999 ! for now don't set to snan until remap dwinds is changed
@@ -3578,35 +3577,27 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !---------------------------------------------------------------------------------
 !
       if(side=='west')then
-        do j=jss,jes
+        do j=jsv,jev
           psc(isv,j) = psc(iss,j)
         enddo
-        psc(iev,jsv) = psc(ies,jss)
-        psc(iev,jev) = psc(ies,jes)
       endif
 !
       if(side=='east')then
-        do j=jss,jes
+        do j=jsv,jev
           psc(iev,j) = psc(ies,j)
         enddo
-        psc(iev,jev) = psc(ies,jes)
-        psc(iev,jev) = psc(ies,jes)
       endif
 !
       if(side=='south')then
-        do i=iss,ies
+        do i=isv,iev
           psc(i,jsv) = psc(i,jss)
         enddo
-        psc(isv,jsv) = psc(iss,jss)
-        psc(iev,jsv) = psc(ies,jss)
       endif
 !
       if(side=='north')then
-        do i=iss,ies
+        do i=isv,iev
           psc(i,jev) = psc(i,jes)
         enddo
-        psc(isv,jev) = psc(iss,jes)
-        psc(iev,jev) = psc(ies,jes)
       endif
 !
       is = iss
@@ -3672,35 +3663,27 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 !---------------------------------------------------------------------------------
 !
       if(side=='west')then
-        do j=jss,jes
+        do j=jsv,jev
           ps(isv,j) = ps(iss,j)
         enddo
-        ps(iev,jsv) = ps(ies,jss)
-        ps(iev,jev) = ps(ies,jes)
       endif
 !
       if(side=='east')then
-        do j=jss,jes
+        do j=jsv,jev
           ps(iev,j) = ps(ies,j)
         enddo
-        ps(iev,jev) = ps(ies,jes)
-        ps(iev,jev) = ps(ies,jes)
       endif
 !
       if(side=='south')then
-        do i=iss,ies
+        do i=isv,iev
           ps(i,jsv) = ps(i,jss)
         enddo
-        ps(isv,jsv) = ps(iss,jss)
-        ps(iev,jsv) = ps(ies,jss)
       endif
 !
       if(side=='north')then
-        do i=iss,ies
+        do i=isv,iev
           ps(i,jev) = ps(i,jes)
         enddo
-        ps(isv,jev) = ps(iss,jes)
-        ps(iev,jev) = ps(ies,jes)
       endif
 
 !---------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**

This removes the workaround of initializing ps_reg to -9999999 Pa in fv_regional_bc.F90 and fixes many other bugs that caused or masked. One bug related to blending has a workaround instead of a fix. A lot of these bugs were fixed by merging in #220. That PR from @kaiyuan-cheng has an elegant replacement for some of my earlier kludgy fixes. Unfortunately, that PR does not allow the model to run in debug mode. I believe this PR has the minimal set of fixes and workarounds needed, until someone comes up with a more elegant solution to the blending bug.

**What is Fixed?**

This PR fixes everything listed here, while related PRs (listed below) at higher levels fix several other issues. See the next section for the one bug that has a workaround instead of a fix.

1. Only valid boundary values are copied to Atm%ps (not to data within the domain)
2. Many uninitialized variables are now initialized with signalling NaN (real_snan)
3. ps_reg is no longer initialzied to -9999999 Pa
4. Replaced "go to 123" with "exit"
5. PR #220 is included. Indexes are corrected so that wind remapping never accesses data outside boundary regions.

**Workaround for Blending Code Receiving Data Outside the Boundary**

The blending code's `array` array contains NaNs in regions it is asked to blend. If my reading of the code is correct, the `array` array is what is being blended, not the boundary conditions themselves. This is probably (but not certainly) regions beyond the boundary in the domain. Any operations with a NaN return NaN (unless the NaN signals), so processing those locations is a no-op (or a SIGFPE). The workaround is to detect non-finite values using `is_not_finite()` and skip them.

I'm concerned by this bug, as it means something may be wrong elsewhere. Someone with better knowledge of the code should look into this. The trouble may originate from the model level, so I've made an issue there (https://github.com/NOAA-EMC/fv3atm/issues/586). It may be as simple as the blending code looping one point farther than it should.

**Testing:**

Fixes #218 

The RRFS regression tests in the ufs-weather-model were compiled in DEBUG=ON mode, and extensively tested on Hera with the Gnu and Intel compilers. Many hours of debugging with gdb, ncview, and other tools. Testing this also required fixing a numerical precision issue in one ccpp physics scheme (https://github.com/ufs-community/ccpp-physics/issues/5, https://github.com/ufs-community/ccpp-physics/pull/6) and changes to the regression tests to get them to fit in 30 minutes (https://github.com/ufs-community/ufs-weather-model/pull/1437). Ultimately, this fixes half of the test variants of RRFS that were failing before (https://github.com/ufs-community/ufs-weather-model/issues/1222). It also obviates the problem of not having enough PS boundary data (https://github.com/ufs-community/ufs-weather-model/issues/1436).

Preliminary results from a real-time parallel have shown this has a small impact on the bulk 1D statistics in a large domain with a large number of ranks. (Hence, boundary ranks have a small fraction of the domain.) However, regression tests have shown it does change the fields. Nobody has done any analysis between those two extremes.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
