### PR TITLE
Hr ave chem

### DIFF
--- a/driver/fvGFS/fv_nggps_diag.F90
+++ b/driver/fvGFS/fv_nggps_diag.F90
@@ -1071,7 +1071,6 @@ contains
     endif
    endif
 
-!    if ( id_o3_ave > 0 .or. id_pm25_ave >0 ) then
      if ( id_o3_ave > 0 .and. id_pm25_ave >0 & 
          .and. id_no3_ave > 0 .and. id_so4_ave >0 & 
          .and. id_nh4_ave > 0 .and. id_ec_ave >0 &
@@ -1183,7 +1182,6 @@ contains
        call mpp_error(FATAL, 'Missing hourly-averaged o3 or pm25 in diag_table')
        stop
     endif
-!   endif
 
    !allocate hailcast met field arrays
    if (do_hailcast) then


### PR DESCRIPTION
**Description**

This PR is considered as a new feature. It is used to calculate total PM2.5 and its compositions such as NO3, SO4, NH4, EC, OC and their hourly averaged values, as well as hourly-averaged O3, NO2, and NO. The changes are used to support AQM v7 implementation.  The PR requires the change of UPP in order to postprocess mode output files.

**How Has This Been Tested?**
The PR has been only tested on Cactus (WCOSS2).  
Please add the following line in the diag_table as an example to write out hourly-averaged PM2.5.
"gfs_dyn",         "pm25_ave",      "pm25_ave",      "fv3_history",  "all",  .false.,  "none",  2

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
