### PR TITLE
calculate hourly-averaged O3 and PM2.5

### DIFF
--- a/driver/fvGFS/fv_nggps_diag.F90
+++ b/driver/fvGFS/fv_nggps_diag.F90
@@ -997,10 +997,10 @@ contains
     call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
             Atm(n)%q,pm25_idx,pm25_ave,nsteps_per_reset,ucf2)
     kdtt1=kdtt1+1
-   else
-    print *,'calculating hourly-averaegtd o3 or pm25'
-    call mpp_error(FATAL, 'Missing hourly-averaged o3 or pm25 in diag_table')
-    stop
+   !else
+   ! print *,'calculating hourly-averaegtd o3 or pm25'
+   ! call mpp_error(FATAL, 'Missing hourly-averaged o3 or pm25 in diag_table')
+   ! stop
    endif
 
    !allocate hailcast met field arrays

--- a/driver/fvGFS/fv_nggps_diag.F90
+++ b/driver/fvGFS/fv_nggps_diag.F90
@@ -988,19 +988,19 @@ contains
         enddo      
        enddo      
     endif
-       call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,o3_idx,o3_ave,nsteps_per_reset,ucf1)
-       call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,no_idx,no_ave,nsteps_per_reset,ucf1)
-       call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,no2_idx,no2_ave,nsteps_per_reset,ucf1)
-       call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,pm25_idx,pm25_ave,nsteps_per_reset,ucf2)
-       kdtt1=kdtt1+1
+    call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
+            Atm(n)%q,o3_idx,o3_ave,nsteps_per_reset,ucf1)
+    call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
+            Atm(n)%q,no_idx,no_ave,nsteps_per_reset,ucf1)
+    call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
+            Atm(n)%q,no2_idx,no2_ave,nsteps_per_reset,ucf1)
+    call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
+            Atm(n)%q,pm25_idx,pm25_ave,nsteps_per_reset,ucf2)
+    kdtt1=kdtt1+1
    else
-       print *,'calculating hourly-averaegtd o3 or pm25'
-       call mpp_error(FATAL, 'Missing hourly-averaged o3 or pm25 in diag_table')
-       stop
+    print *,'calculating hourly-averaegtd o3 or pm25'
+    call mpp_error(FATAL, 'Missing hourly-averaged o3 or pm25 in diag_table')
+    stop
    endif
 
    !allocate hailcast met field arrays

--- a/driver/fvGFS/fv_nggps_diag.F90
+++ b/driver/fvGFS/fv_nggps_diag.F90
@@ -878,7 +878,6 @@ contains
     integer, save :: kdtt = 0, kdtt1 = 0
     real :: avg_max_length
     real,dimension(:,:,:),allocatable :: vort
-!jp    real,dimension(:,:,:),allocatable :: o3,no,no2,pm25
     n = 1
     ngc = Atm(n)%ng
     nq = size (Atm(n)%q,4)

--- a/driver/fvGFS/fv_nggps_diag.F90
+++ b/driver/fvGFS/fv_nggps_diag.F90
@@ -876,6 +876,7 @@ contains
     logical, save :: first_call=.true.
     real, save :: first_time = 0.
     integer, save :: kdtt = 0, kdtt1 = 0
+    real, save :: ucf1 = 1000., ucf2 = 1.
     real :: avg_max_length
     real,dimension(:,:,:),allocatable :: vort
     n = 1
@@ -964,18 +965,18 @@ contains
 
    if ( id_o3_ave > 0 .and. id_no_ave >0 &
        .and. id_no2_ave > 0 .and. id_pm25_ave >0 ) then
-       o3_idx = get_tracer_index (MODEL_ATMOS, 'O3')
-       no_idx = get_tracer_index (MODEL_ATMOS, 'NO')
-       no2_idx = get_tracer_index (MODEL_ATMOS, 'NO2')
-       pm25_idx = get_tracer_index (MODEL_ATMOS, 'PM25_TOT')
-   if (first_call) then
-       call get_time (Time_step_atmos, seconds,  days)
+       o3_idx = get_tracer_index(MODEL_ATMOS, 'O3')
+       no_idx = get_tracer_index(MODEL_ATMOS, 'NO')
+       no2_idx = get_tracer_index(MODEL_ATMOS, 'NO2')
+       pm25_idx = get_tracer_index(MODEL_ATMOS, 'PM25_TOT')
+    if (first_call) then
+       call get_time(Time_step_atmos, seconds,  days)
        first_time=seconds
        first_call=.false.
        kdtt1=0
-   endif
-        nsteps_per_reset = nint(avg_max_length/first_time)
-   if(mod(kdtt1,nsteps_per_reset)==0)then
+    endif
+       nsteps_per_reset = nint(avg_max_length/first_time)
+    if(mod(kdtt1,nsteps_per_reset)==0)then
        do k=1,npzo
         do j=jsco,jeco
          do i=isco,ieco
@@ -986,15 +987,15 @@ contains
          enddo      
         enddo      
        enddo      
-   endif
+    endif
        call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,o3_idx,o3_ave,nsteps_per_reset)
+               Atm(n)%q,o3_idx,o3_ave,nsteps_per_reset,ucf1)
        call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,no_idx,no_ave,nsteps_per_reset)
+               Atm(n)%q,no_idx,no_ave,nsteps_per_reset,ucf1)
        call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,no2_idx,no2_ave,nsteps_per_reset)
+               Atm(n)%q,no2_idx,no2_ave,nsteps_per_reset,ucf1)
        call average_tracer_hy1(isco,ieco,jsco,jeco,isdo,iedo,jsdo,jedo,ncnsto,npzo,&
-               Atm(n)%q,pm25_idx,pm25_ave,nsteps_per_reset)
+               Atm(n)%q,pm25_idx,pm25_ave,nsteps_per_reset,ucf2)
        kdtt1=kdtt1+1
    else
        print *,'calculating hourly-averaegtd o3 or pm25'
@@ -1012,20 +1013,21 @@ contains
  end subroutine fv_nggps_tavg
 !
  subroutine average_tracer_hy1(is,ie,js,je,isd,ied,jsd,jed, &
-                 ncns,npz,tracer,tr_idx,tracer_ave,nstp) 
+                 ncns,npz,tracer,tr_idx,tracer_ave,nstp,unitcf) 
    integer, intent(in):: is, ie, js, je, isd, ied, jsd, jed
    integer, intent(in):: ncns, npz, nstp, tr_idx
+   real, intent(in) :: unitcf
    real, intent(in), dimension(isd:ied,jsd:jed,npz,ncns):: tracer 
    real, intent(inout), dimension(is:ie,js:je,npz):: tracer_ave
    integer i, j, k
-
+!
    do k=1,npz
     do j=js,je
      do i=is,ie
-        tracer_ave(i,j,k)=tracer_ave(i,j,k)+tracer(i,j,k,tr_idx)/nstp
+        tracer_ave(i,j,k)=tracer_ave(i,j,k)+tracer(i,j,k,tr_idx)/nstp*unitcf
      enddo 
     enddo 
-  enddo  
+   enddo  
 
  end subroutine average_tracer_hy1
 

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -197,7 +197,6 @@ module fv_diagnostics_mod
  public :: max_vv, get_vorticity, max_uh
  public :: max_vorticity, max_vorticity_hy1, bunkers_vector, helicity_relative_CAPS
  public :: cs3_interpolator, get_height_given_pressure
- public :: average_tracer_hy1
 #ifdef MOVING_NEST
  public :: interpolate_z, get_pressure_given_height
  public :: fv_diag_reinit
@@ -6171,20 +6170,6 @@ end subroutine eqv_pot
    enddo
 
  end subroutine dbzcalc
-
- subroutine average_tracer_hy1(is, ie, js, je, npz,tracer, tracer_ave,nstp)
-   integer, intent(in):: is, ie, js, je, npz, nstp
-   real, intent(in), dimension(is:ie,js:je,npz):: tracer
-   real, intent(inout), dimension(is:ie,js:je,npz):: tracer_ave
-   integer i, j, k
-   do k=1,npz
-    do j=js,je
-     do i=is,ie
-        tracer_ave(i,j,k)=tracer_ave(i,j,k)+tracer(i,j,k)/nstp
-     enddo  ! i-loop
-    enddo   ! j-loop
-   enddo   ! k-loop
- end subroutine average_tracer_hy1
 
  subroutine max_vorticity_hy1(is, ie, js, je, km, vort, maxvorthy1)
    integer, intent(in):: is, ie, js, je, km

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -197,6 +197,7 @@ module fv_diagnostics_mod
  public :: max_vv, get_vorticity, max_uh
  public :: max_vorticity, max_vorticity_hy1, bunkers_vector, helicity_relative_CAPS
  public :: cs3_interpolator, get_height_given_pressure
+ public :: average_tracer_hy1
 #ifdef MOVING_NEST
  public :: interpolate_z, get_pressure_given_height
  public :: fv_diag_reinit
@@ -6170,6 +6171,20 @@ end subroutine eqv_pot
    enddo
 
  end subroutine dbzcalc
+
+ subroutine average_tracer_hy1(is, ie, js, je, npz,tracer, tracer_ave,nstp)
+   integer, intent(in):: is, ie, js, je, npz, nstp
+   real, intent(in), dimension(is:ie,js:je,npz):: tracer
+   real, intent(inout), dimension(is:ie,js:je,npz):: tracer_ave
+   integer i, j, k
+   do k=1,npz
+    do j=js,je
+     do i=is,ie
+        tracer_ave(i,j,k)=tracer_ave(i,j,k)+tracer(i,j,k)/nstp
+     enddo  ! i-loop
+    enddo   ! j-loop
+   enddo   ! k-loop
+ end subroutine average_tracer_hy1
 
  subroutine max_vorticity_hy1(is, ie, js, je, km, vort, maxvorthy1)
    integer, intent(in):: is, ie, js, je, km


### PR DESCRIPTION
**Description**

This PR is considered as a new feature. It is used to calculate hourly averaged PM2.5 and three gas species (O3, NO, and NO2) and write them on the user-defined output grids (i.e., rotated lat/lon) with the UFS writing component to support AQM v7 implementation. Now total PM2.5 is calculated within the AQM component and passed to the Atmospheric model as a diagnostic tracer. 

**How Has This Been Tested?**

The PR has been only tested on Cactus (WCOSS2).
Please add the following line in the diag_table as an example to write out hourly-averaged PM2.5.
"gfs_dyn", "pm25_ave", "pm25_ave", "fv3_history", "all", .false., "none", 2

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
