### PR TITLE
Fixes for USE_COND ifdef

### DIFF
--- a/driver/GFDL/atmosphere.F90
+++ b/driver/GFDL/atmosphere.F90
@@ -1196,7 +1196,8 @@ contains
     real    tvm
     real    :: zvir, rrg, ginv
 #ifdef USE_COND
-    real, dimension(size(pe,1),size(pe,3),size(pe,2):: peg, pelng
+    real    dlg
+    real, dimension(size(pe,1),size(pe,3),size(pe,2)):: peg, pelng
 #endif
 
     isiz=size(phis,1)


### PR DESCRIPTION
**Description**
This is a bug fix for 2020.04 that adds a missing variable and fixes a missing parenthesis. 

Fixes # (issue)

**How Has This Been Tested?**
Compiling with -DUSE_COND

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
