### PR TITLE
dev/gfdl adj_mass_mmr default value change

### DIFF
--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -892,7 +892,7 @@ module fv_arrays_mod
   integer, pointer :: grid_number
 
   !f1p
-  integer  :: adj_mass_vmr = 2 !0: no correction; 1: AM4/CM4 correction; 2: correction based on convertion of VMR to dry mixing ratio
+  integer  :: adj_mass_vmr = 0 !0: no correction; 1: AM4/CM4 correction; 2: correction based on convertion of VMR to dry mixing ratio
   logical :: w_limiter = .true. ! Fix excessive w - momentum conserving --- sjl
 
   ! options related to regional mode


### PR DESCRIPTION
**Description**

PR #232 implemented a fix to VMR calculation and modified the namelist flag `adj_mass_mmr`.  Previously the default value was `adj_mass_mmr=.false.`  and if a model wanted to use the VMR correction they would set `adj_mass_mmr=.true.`.  Now there are three options: *0, 1, or 2*.  0 is equivalent to .false., 1 to .true., and 2 will use the new fixes for VMR correction.  And the default value is `adj_mass_mmr=2`.  To maintain consistency and not change answers for models using the dev/gfdl branch, This PR changes the defualt to `adj_mass_mmr=0`.  

**How Has This Been Tested?**
Tested with an AM4.2 experiment

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
