### PR TITLE
Main4uwyo

### DIFF
--- a/driver/solo/fv_phys.F90
+++ b/driver/solo/fv_phys.F90
@@ -30,7 +30,7 @@ use hswf_mod,              only: Held_Suarez_Tend
 use fv_sg_mod,             only: fv_subgrid_z
 use fv_update_phys_mod,    only: fv_update_phys
 use fv_timing_mod,         only: timing_on, timing_off
-use monin_obukhov_mod,     only: mon_obkv
+use mon_obkv_mod,          only: mon_obkv
 use tracer_manager_mod,    only: get_tracer_index, adjust_mass
 use field_manager_mod,     only: MODEL_ATMOS
 use fms_mod,               only: error_mesg, FATAL, file_exist, open_namelist_file,  &

--- a/driver/solo/monin_obukhov_drag.F90
+++ b/driver/solo/monin_obukhov_drag.F90
@@ -19,7 +19,7 @@
 !* If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
-module monin_obukhov_mod
+module mon_obkv_mod
 
 !==============================================================================
 ! Kernel routines
@@ -665,4 +665,4 @@ end if
 
 end subroutine monin_obukhov_integral_tq
 
-end module monin_obukhov_mod
+end module mon_obkv_mod


### PR DESCRIPTION
**Description**
There is a namespace collision with [monin_obukhov.F90](https://github.com/NOAA-GFDL/FMS/blob/main/monin_obukhov/monin_obukhov.F90) from FMS and [solo/monin_obhukov_drag.F90](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/blob/main/driver/solo/monin_obukhov_drag.F90) in FV3. These F90 modules both have the same name, which can lead to collisions when both include directories are present.  For the NVidia HPC Toolkit, the collision is an issue for compiling.

Fixes #245 

**How Has This Been Tested?**

nhpc compiles produce a running executable - though there is an nvfortran bug deallocating an allocatable fortran ddt during program termination.  The bug has been filed and being examined by NVidia compiler engineers.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
