### PR TITLE
Ci Fix

### DIFF
--- a/.github/workflows/SHiELD_parallelworks.yml
+++ b/.github/workflows/SHiELD_parallelworks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted]
     name: Checkout Code
     steps:
-    - run: python3 /pw/storage/PWscripts/FV3checkoutStartClusters.py $GITHUB_REF
+    - run: /contrib/fv3/FV3CIScripts/checkout.sh $GITHUB_REF
     
   build:
     runs-on: [self-hosted]
@@ -19,13 +19,13 @@ jobs:
       fail-fast: true
       max-parallel: 3
       matrix:
-        runpath: [/pw/storage/PWscripts]
-        runscript: [FV3swStartClusters.py, FV3nhStartClusters.py, FV3hydroStartClusters.py]
+        runpath: [/contrib/fv3/FV3CIScripts/]
+        runscript: [swcompile.sh, nhcompile.sh, hydrocompile.sh]
     steps:
       - env:
           RUNPATH: ${{ matrix.runpath }}
           RUNSCRIPT: ${{ matrix.runscript }}
-        run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
+        run: $RUNPATH/$RUNSCRIPT $GITHUB_REF
         
   test:
     runs-on: [self-hosted]
@@ -35,18 +35,10 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        runpath: [/pw/storage/PWscripts]
-        runscript: [FV3C128r20.solo.superCStartClusters.py]
+        runpath: [/contrib/fv3/FV3CIScripts/]
+        runscript: [C128r20.solo.superC.sh]
     steps:
       - env:
           RUNPATH: ${{ matrix.runpath }}
           RUNSCRIPT: ${{ matrix.runscript }}
-        run: python3 $RUNPATH/$RUNSCRIPT $GITHUB_REF
-        
-  shutdowncluster:
-    runs-on: [self-hosted]
-    name: Shutdown cluster
-    if: always()
-    needs: [checkout, build, test]
-    steps:
-      - run: python3 /home/Lauren.Chilutti/pw/storage/PWscripts/stopClusters.py cifv3
+        run: $RUNPATH/$RUNSCRIPT $GITHUB_REF


### PR DESCRIPTION
**Description**

Parallelworks (the cloud computing system we are using to run the CI in this repo) was updated and required that I move the location of the GitHub runner software.  I now store the GitHub runner software on our CI cluster, the CI cluster will be left on to maintain communication with GitHub.  I no longer need to have a shutdown step in the workflow, and have removed a layer of python scripts and replaced them with runscripts on the PW cluster.

Fixes #247 

**How Has This Been Tested?**

It will be tested by this PR

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
