### PR TITLE
removes redundant id_tracer(itrac) > 0 check

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -3563,7 +3563,7 @@ contains
 
         do itrac=1, Atm(n)%ncnst
           call get_tracer_names (MODEL_ATMOS, itrac, tname)
-          if (id_tracer(itrac) > 0 .and. itrac.gt.nq) then
+          if (itrac.gt.nq) then
             used = send_data (id_tracer(itrac), Atm(n)%qdiag(isc:iec,jsc:jec,:,itrac), Time )
           else
             used = send_data (id_tracer(itrac), Atm(n)%q(isc:iec,jsc:jec,:,itrac), Time )


### PR DESCRIPTION
**Description**

removes redundant id_tracer(itrac) > 0 check before calling `send_data`, 

send_data does nothing if the id is negative, so there is no need for it. 

Fixes #249

**How Has This Been Tested?**
AM4 with intel21 in debug mode

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
