### PR TITLE
[dev/emc] Address negative hydrometeors

### DIFF
--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -799,7 +799,19 @@ contains
        if (snowwat > 0) call prt_mxm('snowwat_dyn', q(isd,jsd,1,snowwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
        if (graupel > 0) call prt_mxm('graupel_dyn', q(isd,jsd,1,graupel), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
        if (hailwat > 0) call prt_mxm('hailwat_dyn', q(isd,jsd,1,hailwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-     endif
+       if ( flagstruct%range_warn ) then
+       !tgs -  check the location of negative hydrometeors
+        call range_check('liq_wat', q(:,:,:,liq_wat), is, ie, js, je, ng, npz, gridstruct%agrid,   &
+                          -1.e-20, 1.e20, bad_range,fv_time)
+        call range_check('rainwat', q(:,:,:,rainwat), is, ie, js, je, ng, npz, gridstruct%agrid,   &
+                          -1.e-20, 1.e20, bad_range,fv_time)
+        call range_check('graupel', q(:,:,:,graupel), is, ie, js, je, ng, npz, gridstruct%agrid,   &
+                          -1.e-20, 1.e20, bad_range,fv_time)
+        call range_check('snowwat', q(:,:,:,snowwat), is, ie, js, je, ng, npz, gridstruct%agrid,   &
+                          -1.e-20, 1.e20, bad_range,fv_time)
+       endif
+
+     endif ! fv_debug
 #ifdef AVEC_TIMERS
                                                   call avec_timer_stop(6)
 #endif

--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -1721,6 +1721,10 @@ contains
              qv2(i,j) = qv2(i,j) - dq
              pt2(i,j) = pt2(i,j) + dq*(icpk(i,j)+lcpk(i,j))
         endif
+!tgs--  Give up and set graupel to zero 
+        if ( qg2(i,j)<0.) then
+             qg2(i,j) = 0.
+        endif
 
 !--------------
 ! Liquid phase:


### PR DESCRIPTION
**Description**

Submitted on behalf of @tanyasmirnova

* In fv_sg.F90 set negative graupel to zero in case there are not enough adjacent hydrometeors to compensate for negative values.

* In fv_dynamics.F90 added range_check for negative hydrometeors to identify the location where this happens. No impact on model performance.

The treatment of hydrometeors was problematic for higher-resolution runs and came about while performing experiments with RRFS configurations.

This is a standalone modification that does not have other dependencies.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

For scientific testing, this modification has been included as part of long-term testing with RRFS experimental runs (retros and near real-time), which regularly run on Hera and Jet with Intel compilers. For these RRFS tests, the change has been combined with several other code modifications.

The code has been tested on its own with a recent version of the weather model regression test (e3ad8081 from Mar 14) using a Hera intel configuration. It requires a new baseline and passes all Hera intel tests compared to the new baseline.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
