### PR TITLE
Hailcast code bugfix in file tools/module_diag_hailcast.F90

### DIFF
--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -791,6 +791,7 @@ CONTAINS
             KBAS = k
          ENDIF
     ENDDO
+    KBAS = MAX(KBAS, 2)     ! start at least from 2 to avoid cloud base at k=1, since then k-1 would be zero and out of bounds
     !QC - our embryo can't start below the cloud base.
     !IF (KFZL .lt. KBAS) THEN
     !   KFZL = KBAS


### PR DESCRIPTION
**Description**

Just add one line (about line 794) in file _tools/module_diag_hailcast.F90_,

> KBAS = MAX(KBAS, 2)

The purpose is to make sure the cloud base starts from at least 2 and to avoid the cloud base at `k=1` because `KBAS-1` is used later in the code which will cause an out-of-bound error in the debug mode.



**How Has This Been Tested?**

It is tested on macOS using GNU compiler.

This is just a bug fix and should not impact other parts of the model.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
