### PR TITLE
add Ubar definition to cases 0, 6, 7, & 9

### DIFF
--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -874,6 +874,7 @@
       call mp_stop()
       stop
       case(0)
+         UBar = 0.
          do j=jsd,jed
             do i=isd,ied
 
@@ -1144,6 +1145,7 @@
 
 
       case(6)
+         Ubar = 0.
          gh0  = 8.E3*Grav
          R    = 4.
          omg  = 7.848E-6
@@ -1197,6 +1199,7 @@
 
       case(7)
 ! Barotropically unstable jet
+         Ubar = 0.
          gh0  = 10.E3*Grav
          phis = 0.0
          r0 = radius/12.
@@ -1369,6 +1372,7 @@
 
       case(9)
 
+         Ubar = 0.
          jm1 = jm - 1
          DDP = PI/DBLE(jm1)
          DP  = DDP


### PR DESCRIPTION
**Description**
This PR fixes undefined values for Ubar when running idealized shallow-water for cases 0, 6, 7, & 9.


Fixes #255 

**How Has This Been Tested?**
It has been tested in idealized debug runs where undefined variables can be trapped via FP exception handling.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
