### PR TITLE
dev/gfdl branch remove deprecated io 

### DIFF
--- a/GFDL_tools/fv_ada_nudge.F90
+++ b/GFDL_tools/fv_ada_nudge.F90
@@ -63,7 +63,7 @@ module fv_ada_nudge_mod
 
  use fms2_io_mod,       only : register_restart_field, open_file, close_file, &
                                read_restart, register_field, &
-                               register_variable_attribute, file_exists, FmsNetcdfFile_t
+                               register_variable_attribute, file_exists, FmsNetcdfDomainFile_t
  use fv_io_mod,         only : fv_io_register_axis
  use axis_utils_mod, only : frac_index
 
@@ -235,7 +235,7 @@ module fv_ada_nudge_mod
   integer :: id_u_da, id_v_da, id_t_da, id_q_da, id_ps_da ! snz
   integer :: id_ada
 
-  type(FmsNetcdfFile_t) :: ada_driver_restart ! snz
+  type(FmsNetcdfDomainFile_t) :: ada_driver_restart ! snz
   character(len=*), parameter :: restart_file="INPUT/ada_driver.res.nc" ! snz
   character(len=8), dimension(4) :: dim_names_4d
 

--- a/GFDL_tools/fv_ada_nudge.F90
+++ b/GFDL_tools/fv_ada_nudge.F90
@@ -47,7 +47,7 @@ module fv_ada_nudge_mod
  use mpp_domains_mod,   only: mpp_get_data_domain ! snz
  use time_manager_mod,  only: time_type,  get_time, get_date, set_date, increment_time
 
- use grid_mod, only : define_cube_mosaic ! snz
+ use grid2_mod, only : define_cube_mosaic ! snz
 
  use fv_grid_utils_mod, only: great_circle_dist, intp_great_circle
  use fv_grid_utils_mod, only: latlon2xyz, vect_cross, normalize_vect
@@ -65,7 +65,7 @@ module fv_ada_nudge_mod
                                read_restart, register_field, &
                                register_variable_attribute, file_exists, FmsNetcdfDomainFile_t
  use fv_io_mod,         only : fv_io_register_axis
- use axis_utils_mod, only : frac_index
+ use axis_utils2_mod, only : frac_index
 
 #ifdef ENABLE_ADA
  use ada_types_mod, only : model_data_type

--- a/driver/solo/atmosphere.F90
+++ b/driver/solo/atmosphere.F90
@@ -29,16 +29,15 @@ module atmosphere_mod
 
 
 use constants_mod, only: grav, kappa, cp_air, pi, rdgas, rvgas, SECONDS_PER_DAY
-use fms_mod,       only: file_exist, open_namelist_file,   &
-                         error_mesg, FATAL,                &
+use fms_mod,       only: error_mesg, FATAL,                &
                          check_nml_error, stdlog, stdout,  &
                          write_version_number,             &
-                         close_file, set_domain, nullify_domain, mpp_pe, mpp_root_pe, &
+                         mpp_pe, mpp_root_pe, &
                          mpp_error, FATAL, NOTE
+use fms2_io_mod,   only: file_exists
 use mpp_mod,       only: input_nml_file
 use time_manager_mod, only: time_type, get_time, set_time, operator(+)
 use mpp_domains_mod,  only: domain2d
-use mpp_io_mod,       only: mpp_close
 use mpp_mod,          only: input_nml_file
 !------------------
 ! FV specific codes:
@@ -119,7 +118,7 @@ contains
     dt_atmos = real(sec)
 
   !----- initialize FV dynamical core -----
-    cold_start = (.not.file_exist('INPUT/fv_core.res.nc') .and. .not.file_exist('INPUT/fv_core.res.tile1.nc'))
+    cold_start = (.not.file_exists('INPUT/fv_core.res.nc') .and. .not.file_exists('INPUT/fv_core.res.tile1.nc'))
 
     call fv_control_init(Atm, dt_atmos, this_grid, grids_on_this_pe, p_split)  ! allocates Atm components
 
@@ -426,8 +425,6 @@ contains
           cycle
        endif
 
-       call set_domain(Atm(n)%domain)  ! needed for diagnostic output done in fv_dynamics
-
        if ( Atm(n)%flagstruct%nudge_ic )     &
             call  fv_nudge(Atm(n)%npz, Atm(n)%bd%isc, Atm(n)%bd%iec, Atm(n)%bd%jsc, Atm(n)%bd%jec, Atm(n)%ng, &
             Atm(n)%u, Atm(n)%v, Atm(n)%w, Atm(n)%delz, Atm(n)%delp, Atm(n)%pt, dt_atmos/real(abs(p_split)), Atm(n)%flagstruct%hydrostatic )
@@ -490,7 +487,6 @@ contains
                                                         call timing_off('FV_PHYS')
        endif
 
-       call nullify_domain()
     end do
 
     if (ngrids > 1 .and. p_split > 0) then
@@ -515,7 +511,6 @@ contains
           zvir = rvgas/rdgas - 1.
        endif
 
-       call nullify_domain()
        call timing_on('FV_DIAG')
        call fv_diag(Atm(n:n), zvir, fv_time, Atm(n)%flagstruct%print_freq)
 

--- a/driver/solo/fv_phys.F90
+++ b/driver/solo/fv_phys.F90
@@ -33,14 +33,16 @@ use fv_timing_mod,         only: timing_on, timing_off
 use monin_obukhov_mod,     only: mon_obkv
 use tracer_manager_mod,    only: get_tracer_index, adjust_mass
 use field_manager_mod,     only: MODEL_ATMOS
-use fms_mod,               only: error_mesg, FATAL, file_exist, open_namelist_file,  &
-                                 check_nml_error, mpp_pe, mpp_root_pe, close_file, &
-                                 write_version_number, stdlog, mpp_error
+use fms_mod,               only: error_mesg, FATAL,  &
+                                 check_nml_error, mpp_pe, mpp_root_pe, &
+                                 mpp_error
+use fms2_io_mod,           only: file_exists
 use fv_mp_mod,             only: is_master, mp_reduce_max
 use fv_diagnostics_mod,    only: prt_maxmin, gn
 
 use fv_arrays_mod,          only: fv_grid_type, fv_flags_type, fv_nest_type, fv_grid_bounds_type, phys_diag_type, nudge_diag_type
 use mpp_domains_mod,       only: domain2d
+use mpp_mod,               only: input_nml_file
 use diag_manager_mod,      only: register_diag_field, register_static_field, send_data
 use qs_tables_mod,         only: qs_wat_init, qs_wat
 
@@ -1582,27 +1584,25 @@ endif
     master = is_master()
 
 !   ----- read and write namelist -----
-    if ( file_exist('input.nml')) then
-         unit = open_namelist_file ('input.nml')
-         read  (unit, nml=sim_phys_nml, iostat=io, end=10)
+    if ( file_exists('input.nml')) then
+         read  (input_nml_file, nml=sim_phys_nml, iostat=io)
          ierr = check_nml_error(io,'sim_phys_nml')
 
          if (do_K_warm_rain) then
-            read  (unit, nml=Kessler_sim_phys_nml, iostat=io, end=10)
+            read  (input_nml_file, nml=Kessler_sim_phys_nml, iostat=io)
             ierr = check_nml_error(io,'Kessler_sim_phys_nml')
          endif
 
          if (do_GFDL_sim_phys) then
-            read  (unit, nml=GFDL_sim_phys_nml, iostat=io, end=10)
+            read  (input_nml_file, nml=GFDL_sim_phys_nml, iostat=io)
             ierr = check_nml_error(io,'GFDL_sim_phys_nml')
          endif
 
          if (do_reed_sim_phys) then
-            read  (unit, nml=reed_sim_phys_nml, iostat=io, end=10)
+            read  (input_nml_file, nml=reed_sim_phys_nml, iostat=io)
             ierr = check_nml_error(io,'reed_sim_phys_nml')
          endif
 
- 10     call close_file (unit)
     endif
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/driver/solo/fv_phys.F90
+++ b/driver/solo/fv_phys.F90
@@ -36,7 +36,6 @@ use field_manager_mod,     only: MODEL_ATMOS
 use fms_mod,               only: error_mesg, FATAL,  &
                                  check_nml_error, mpp_pe, mpp_root_pe, &
                                  mpp_error
-use fms2_io_mod,           only: file_exists
 use fv_mp_mod,             only: is_master, mp_reduce_max
 use fv_diagnostics_mod,    only: prt_maxmin, gn
 
@@ -1584,25 +1583,22 @@ endif
     master = is_master()
 
 !   ----- read and write namelist -----
-    if ( file_exists('input.nml')) then
-         read  (input_nml_file, nml=sim_phys_nml, iostat=io)
-         ierr = check_nml_error(io,'sim_phys_nml')
+    read  (input_nml_file, nml=sim_phys_nml, iostat=io)
+     ierr = check_nml_error(io,'sim_phys_nml')
 
-         if (do_K_warm_rain) then
-            read  (input_nml_file, nml=Kessler_sim_phys_nml, iostat=io)
-            ierr = check_nml_error(io,'Kessler_sim_phys_nml')
-         endif
+    if (do_K_warm_rain) then
+       read  (input_nml_file, nml=Kessler_sim_phys_nml, iostat=io)
+       ierr = check_nml_error(io,'Kessler_sim_phys_nml')
+    endif
 
-         if (do_GFDL_sim_phys) then
-            read  (input_nml_file, nml=GFDL_sim_phys_nml, iostat=io)
-            ierr = check_nml_error(io,'GFDL_sim_phys_nml')
-         endif
+    if (do_GFDL_sim_phys) then
+       read  (input_nml_file, nml=GFDL_sim_phys_nml, iostat=io)
+       ierr = check_nml_error(io,'GFDL_sim_phys_nml')
+    endif
 
-         if (do_reed_sim_phys) then
-            read  (input_nml_file, nml=reed_sim_phys_nml, iostat=io)
-            ierr = check_nml_error(io,'reed_sim_phys_nml')
-         endif
-
+    if (do_reed_sim_phys) then
+       read  (input_nml_file, nml=reed_sim_phys_nml, iostat=io)
+       ierr = check_nml_error(io,'reed_sim_phys_nml')
     endif
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/driver/solo/ocean_rough.F90
+++ b/driver/solo/ocean_rough.F90
@@ -25,7 +25,6 @@ module ocean_rough_mod
 
 use       fms_mod, only: error_mesg, FATAL, &
                          check_nml_error, mpp_pe, mpp_root_pe
-use       fms2_io_mod, only: file_exists
 use       mpp_mod, only: input_nml_file
 
 implicit none
@@ -101,7 +100,7 @@ contains
    integer :: unit, ierr, io
 
 !   ----- read and write namelist -----
-    if ( read_namelist .and. file_exists('input.nml')) then
+    if ( read_namelist ) then
         read (input_nml_file, nml=ocean_rough_nml, iostat=io)
         ierr = check_nml_error(io,'ocean_rough_nml')
         if(master) write(*,*)'ierr =',ierr

--- a/driver/solo/ocean_rough.F90
+++ b/driver/solo/ocean_rough.F90
@@ -23,9 +23,10 @@ module ocean_rough_mod
 
 !-----------------------------------------------------------------------
 
-use       fms_mod, only: error_mesg, FATAL, file_exist, open_namelist_file,  &
-                         check_nml_error, mpp_pe, mpp_root_pe, close_file, &
-                         write_version_number, stdlog
+use       fms_mod, only: error_mesg, FATAL, &
+                         check_nml_error, mpp_pe, mpp_root_pe
+use       fms2_io_mod, only: file_exists
+use       mpp_mod, only: input_nml_file
 
 implicit none
 private
@@ -100,15 +101,10 @@ contains
    integer :: unit, ierr, io
 
 !   ----- read and write namelist -----
-    if ( read_namelist .and. file_exist('input.nml')) then
-          unit = open_namelist_file ('input.nml')
-          if(master) write(*,*)'read input, unit', unit
-           ierr=1; do while (ierr /= 0)
-           read  (unit, nml=ocean_rough_nml, iostat=io, end=10)
-           ierr = check_nml_error(io,'ocean_rough_nml')
-           if(master) write(*,*)'ierr =',ierr
-        enddo
- 10     call close_file (unit)
+    if ( read_namelist .and. file_exists('input.nml')) then
+        read (input_nml_file, nml=ocean_rough_nml, iostat=io)
+        ierr = check_nml_error(io,'ocean_rough_nml')
+        if(master) write(*,*)'ierr =',ierr
         if(master) write(*,*)'do_init=',do_init
         if(master) write(*,*)'rough_scheme=',rough_scheme
         read_namelist = .false.

--- a/tools/coarse_graining.F90
+++ b/tools/coarse_graining.F90
@@ -21,7 +21,7 @@
 
 module coarse_graining_mod
 
-  use fms_mod, only: check_nml_error, close_file, open_namelist_file
+  use fms_mod, only: check_nml_error
   use mpp_domains_mod, only: domain2d, mpp_define_io_domain, mpp_define_mosaic, mpp_get_compute_domain
   use mpp_mod, only: FATAL, input_nml_file, mpp_error, mpp_npes
   use statistics_mod, only: mode

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -55,7 +55,7 @@ module fv_grid_tools_mod
   use fms2_io_mod,       only: file_exists, variable_exists, open_file, read_data, &
                                get_global_attribute, get_variable_attribute, &
                                close_file, get_mosaic_tile_grid, FmsNetcdfFile_t
-  use mosaic_mod,       only : get_mosaic_ntiles
+  use mosaic2_mod,       only : get_mosaic_ntiles
 
   use mpp_mod, only: mpp_transmit, mpp_recv
   implicit none
@@ -133,6 +133,10 @@ contains
 
     call get_mosaic_tile_grid(atm_hgrid, atm_mosaic, Atm%domain)
 
+    if (open_file(Grid_input, atm_mosaic, "read")) then
+      ntiles = get_mosaic_ntiles(Grid_input)
+      call close_file(Grid_input)
+    endif
     grid_form = "none"
     if (open_file(Grid_input, atm_hgrid, "read")) then
        call get_global_attribute(Grid_input, "history", attvalue)
@@ -140,7 +144,6 @@ contains
     if(grid_form .NE. "gnomonic_ed") call mpp_error(FATAL, &
          "fv_grid_tools(read_grid): the grid should be 'gnomonic_ed' when reading from grid file, contact developer")
 
-    ntiles = get_mosaic_ntiles(atm_mosaic)
     if( .not. Atm%gridstruct%bounded_domain) then  !<-- The regional setup has only 1 tile so do not shutdown in that case.
     if(ntiles .NE. 6) call mpp_error(FATAL, &
        'fv_grid_tools(read_grid): ntiles should be 6 in mosaic file '//trim(atm_mosaic) )

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -37,7 +37,7 @@
 
 module fv_iau_mod
 
-  use fms_mod,             only: file_exist
+  use fms2_io_mod,         only: file_exists
   use mpp_mod,             only: mpp_error, FATAL, NOTE, mpp_pe
   use mpp_domains_mod,     only: domain2d
 
@@ -189,7 +189,7 @@ subroutine IAU_initialize (IPD_Control, IAU_Data,Init_parm)
     npz = IPD_Control%levs
     fname = 'INPUT/'//trim(IPD_Control%iau_inc_files(1))
 
-    if( file_exist(fname) ) then
+    if( file_exists(fname) ) then
       call open_ncfile( fname, ncid )        ! open the file
       call get_ncdim1( ncid, 'lon',   im)
       call get_ncdim1( ncid, 'lat',   jm)
@@ -461,7 +461,7 @@ subroutine read_iau_forcing(IPD_Control,increments,fname)
 
     npz = IPD_Control%levs
 
-    if( file_exist(fname) ) then
+    if( file_exists(fname) ) then
       call open_ncfile( fname, ncid )        ! open the file
     else
       call mpp_error(FATAL,'==> Error in read_iau_forcing: Expected file '&

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -48,7 +48,6 @@ module fv_restart_mod
   use mpp_mod,             only: mpp_get_current_pelist, mpp_npes, mpp_set_current_pelist
   use mpp_mod,             only: mpp_send, mpp_recv, mpp_sync_self, mpp_pe, mpp_sync
   use fms2_io_mod,         only: file_exists, set_filename_appendix, FmsNetcdfFile_t, open_file, close_file
-  use fms_io_mod,          only: fmsset_filename_appendix=> set_filename_appendix
   use test_cases_mod,      only: alpha, init_case, init_double_periodic!, init_latlon
   use fv_mp_mod,           only: is_master, mp_reduce_min, mp_reduce_max, corners_YDir => YDir, fill_corners, tile_fine, global_nest_domain
   use fv_surf_map_mod,     only: sgh_g, oro_g
@@ -202,7 +201,6 @@ contains
        if (Atm(n)%neststruct%nested .and. n==this_grid) then
           write(gnn,'(A4, I2.2)') "nest", Atm(n)%grid_number
           call set_filename_appendix(gnn)
-          call fmsset_filename_appendix(gnn)
        endif
 
        !3preN. Topography BCs for nest, including setup for blending


### PR DESCRIPTION
**Description**

Removing the final remaining deprecated fmsio calls within the dev/gfdl branch.

Fixes #256 

**How Has This Been Tested?**

Still needs to be fully tested - requires that all components of the GFDL models be updated.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
