### PR TITLE
Revert 2c8363e057dde026e65ddcec1b62c18d5e260017 to allow compiler opt…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,6 @@ add_library(FV3::fv3 ALIAS fv3)
 
 set_property(SOURCE model/nh_utils.F90 APPEND_STRING PROPERTY COMPILE_FLAGS "${FAST}")
 set_property(SOURCE model/fv_mapz.F90  APPEND_STRING PROPERTY COMPILE_FLAGS "${FAST}")
-set_property(SOURCE tools/fv_diagnostics.F90  APPEND_STRING PROPERTY COMPILE_FLAGS "-O0")
 
 set_target_properties(fv3 PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/fv3)
 target_include_directories(fv3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/fv3>

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -4326,18 +4326,9 @@ contains
       integer year, month, day, hour, minute, second
 
       if ( present(bad_range) ) bad_range = .false.
-      qmin = q(is,js)
-      qmax = qmin
 
-      do j=js,je
-         do i=is,ie
-            if( q(i,j) < qmin ) then
-                qmin = q(i,j)
-            elseif( q(i,j) > qmax ) then
-                qmax = q(i,j)
-            endif
-          enddo
-      enddo
+      qmin=minval(q(is:ie,js:je))
+      qmax=maxval(q(is:ie,js:je))
 
       call mp_reduce_min(qmin)
       call mp_reduce_max(qmax)

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -4270,20 +4270,9 @@ contains
       integer year, month, day, hour, minute, second
 
       if ( present(bad_range) ) bad_range = .false.
-      qmin = q(is,js,1)
-      qmax = qmin
 
-      do k=1,km
-      do j=js,je
-         do i=is,ie
-            if( q(i,j,k) < qmin ) then
-                qmin = q(i,j,k)
-            elseif( q(i,j,k) > qmax ) then
-                qmax = q(i,j,k)
-            endif
-          enddo
-      enddo
-      enddo
+      qmin=minval(q(is:ie,js:je,1:km))
+      qmax=maxval(q(is:ie,js:je,1:km))
 
       call mp_reduce_min(qmin)
       call mp_reduce_max(qmax)


### PR DESCRIPTION
…imization.  Also use minval/maxval intrinsic functions instead of a loop nest in range_check_3d()

**Description**
Performance profiling of a HAFS case on NOAA systems revealed significant of time was spent in subroutine range_check_3d().  This commit effectively reverts a commit from Oct 2021 (see below).  This commit also changes the code to use the minval() and maxval() fortran intrinsics.

commit 2c8363e057dde026e65ddcec1b62c18d5e260017
Author: Xiaqiong Zhou <Xiaqiong.Zhou@noaa.gov>
Date:   Thu Oct 21 17:51:10 2021 +0000
    Revise back the range definition form. The compiling issue on DELL can be fixed by using -O0 instead of -O2 to compile fv_diagnostics.F90

I requested more details from Xiaqiong Zhou and got the following responses.

> It is a very strange error when compiling fv_diagostics.F90 on DELL (OK on HERA, Orion et al).
> vsrange = (/ -200., 200. /) was not accepted but it is OK to use
> vsrange(1) = -200. ; vsrange(2) = 200.
> In order to keep the original form as vsrange = (/ -200., 200. /), -O0 instead of -O2 to compile fv_diagnostics.F90 in dynamics.
> 
> DELL was retired. It should be an Intel compiler but I do not remember the version.

I don't see any compile time issues using ifort-19.1.3.304 at -O2 on the WCOSS2 systems.

**How Has This Been Tested?**
The modifications have been tested on WCOSS2 systems Acorn and Dogwood using a HAFS case as well as on Cactus and Dogwood by running the UFS (develop branch cloned on 17 April) regression suite.

Scenarios:
1. Unmodified code and compiler flags (Baseline)
2. Delete the line in FV3/atmos_cubed_sphere/CMakeLists.txt that adds "-O0" to the compile flags.  Thus, this file gets compiled with the global defaults
3. Replace the nested loop calculation in range_check_3d() (not in range_check_2d) with calls to the minval() and maxval() intrinsic functions.
4. Same as scenario three with the addition of minval and maxval intrinsics in range_check_2d.

HAFS case regional simulation with one nest
The case was run on 26 nodes of the Acorn system for a 126 hour simulation.
```
Parent grid:
  layout = 24,20
  npx = 1321
  npy = 1201
  ntiles = 1
  npz = 81

Nest grid:
  layout = 20,12
  npx = 601
  npy = 601
  ntiles = 1
  npz = 81

The 26 nodes are allocated as follows.
ATM_petlist_bounds: 000 735
OCN_petlist_bounds: 736 855
MED_petlist_bounds: 736 855
```

---
Performance metric:
Add up the phase1 and phase2 timings printed in the output listing
grep PASS stdout | awk '{t+=$10;print t}' | tail -1
The units are seconds.
|   Scenario  |   Trial1    |    Trial2   |
| -------------- | ------------ | ----------- |
| 1 | 7881  |   7866.69 |
| 2 | 7206.2   |    7200.81 |
| 3 | 7179.37 | Not run |
| 4 | 7180.67   |  7163.4 |

Validation:
Using scenario four, the UFS regression suite revealed numerous diagnostic variables changed numerically.  A review of all files declared as "NOT OK" by the pass/fail comparison revealed that all of those variables are calculated using routines found in fv_diagnostics.F90 (see attached file variables.txt)
[variables.txt](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/files/11297839/variables.txt)

Some of these variables show up in files that are part of the UFS regression suite pass/fail comparisons so a new baseline will be needed. 

Comparison between stdout from scenario1 and scenario4 revealed certain variables related to tropical cyclone (TC) tracking changed at the 7th significant digit.  A code review revealed that those variables are also calculated using routines from fv_diagnostics.F90

E.g. from time step 6299
 u700 g2 max =    14.35157      min =   -9.42382**7**        |	 u700 g2 max =    14.35157      min =   -9.42382**8**    
 u850 g2 max =    7.198**199**      min =   -18.35876        |	 u850 g2 max =    7.198**200**      min =   -18.35876    
 v700 g2 max =    8.67357**2**      min =   -15.10008        |	 v700 g2 max =    8.67357**1**      min =   -15.10008

Comparing output from the TC tracker printed to stdout revealed no differences between scenario1 and scenario4.

E.g. the last output from a 126 hour simulation.
==> Baseline_5Day_736p/tracker.txt <==
 tracker fixlon= 350.647 fixlat=  30.150 ifix=   302 jfix=   302 pmin=  100795.047 vmax=  16.500 rmw= 119.294

==> RANGECHECKnD-GlobalminvalmaxvalOnly_736p/tracker.txt <==
 tracker fixlon= 350.647 fixlat=  30.150 ifix=   302 jfix=   302 pmin=  100795.047 vmax=  16.500 rmw= 119.294


**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
