### PR TITLE
Write BCs restart files from fv_dyn_restart_output

### DIFF
--- a/driver/fvGFS/fv_ufs_restart_io.F90
+++ b/driver/fvGFS/fv_ufs_restart_io.F90
@@ -6,6 +6,7 @@ module fv_ufs_restart_io_mod
   use tracer_manager_mod, only: get_tracer_names
   use field_manager_mod,  only: MODEL_ATMOS
   use atmosphere_mod,     only: atmosphere_resolution
+  use fv_io_mod,          only: fv_io_write_BCs
 
   implicit none
 
@@ -156,7 +157,7 @@ module fv_ufs_restart_io_mod
 
    implicit none
 
-   type(fv_atmos_type), intent(in) :: Atm
+   type(fv_atmos_type), intent(inout) :: Atm
    character(len=*), intent(in) :: timestamp
 
    integer :: isc, iec, jsc, jec, nx, ny
@@ -221,6 +222,11 @@ module fv_ufs_restart_io_mod
 
    ! Instead of creating yet another esmf bundle just to write Atm%ak and Atm%bk, write them here synchronously
    call write_ak_bk(Atm, timestamp)
+
+   ! Write bcs restarts
+   if (Atm%neststruct%nested) then
+     call fv_io_write_BCs(Atm)
+   endif
 
  end subroutine fv_dyn_restart_output
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -4891,7 +4891,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
        if (fraction_interval .eq. 0.0 .and. it .gt. 1) then
         fraction_interval=1.0
         if (is_master()) then
-         write(0,*) 'reset of fraction_interval ', trim(bc_vbl_name),it, fcst_time
+         write(*,*) 'reset of fraction_interval ', trim(bc_vbl_name),it, fcst_time
         endif
        endif
 


### PR DESCRIPTION
**Description**

Thsi PR updates fv_dyn_restart_output subroutine in driver/fvGFS/fv_ufs_restart_io.F90 by adding a call to fv_io_write_BCs to write out BCs restart files from the ufs-weather-model write component. This is used by nested domains.

**How Has This Been Tested?**

ufs-weather-model regression tests on Hera

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
