### PR TITLE
MR 117 from Gitlab: Pass the namelist variables from the dycore to the physics during the initialization

### DIFF
--- a/driver/SHiELD/atmosphere.F90
+++ b/driver/SHiELD/atmosphere.F90
@@ -657,10 +657,12 @@ contains
  end subroutine atmosphere_pref
 
 
- subroutine atmosphere_control_data (i1, i2, j1, j2, kt, p_hydro, hydro, tile_num)
+ subroutine atmosphere_control_data (i1, i2, j1, j2, kt, p_hydro, hydro, tile_num, &
+                                     do_inline_mp, do_cosp)
    integer, intent(out)           :: i1, i2, j1, j2, kt
    logical, intent(out), optional :: p_hydro, hydro
    integer, intent(out), optional :: tile_num
+   logical, intent(out), optional :: do_inline_mp, do_cosp
    i1 = Atm(mygrid)%bd%isc
    i2 = Atm(mygrid)%bd%iec
    j1 = Atm(mygrid)%bd%jsc
@@ -670,6 +672,8 @@ contains
    if (present(p_hydro)) p_hydro = Atm(mygrid)%flagstruct%phys_hydrostatic
    if (present(  hydro))   hydro = Atm(mygrid)%flagstruct%hydrostatic
    if (present(tile_num)) tile_num = Atm(mygrid)%global_tile
+   if (present(do_inline_mp)) do_inline_mp = Atm(mygrid)%flagstruct%do_inline_mp
+   if (present(do_cosp)) do_cosp = Atm(mygrid)%flagstruct%do_cosp
 
  end subroutine atmosphere_control_data
 
@@ -1898,7 +1902,6 @@ contains
            enddo
         enddo
     endif
-    IPD_Data(nb)%Statein%dycore_hydrostatic = Atm(mygrid)%flagstruct%hydrostatic
     IPD_Data(nb)%Statein%nwat = Atm(mygrid)%flagstruct%nwat
   enddo
 


### PR DESCRIPTION
**Description**

Passing namelist variables from dycore to physics during initialization.  Requires:
https://github.com/NOAA-GFDL/atmos_drivers/pull/22
https://github.com/NOAA-GFDL/SHiELD_physics/pull/21

Fixes # (issue)

**How Has This Been Tested?**

Tested by Linjiong

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
