### PR TITLE
Use MPI_Bcast instead of multiple p2p messages to update nest from parent

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -2469,7 +2469,6 @@ contains
                             0, 0, isg, ieg, jsg, jeg, Atm(this_grid)%bd)
     endif
 
-    call mpp_sync_self
     deallocate(g_dat)
 
   end subroutine fill_nested_grid_cpl

--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -2433,7 +2433,6 @@ contains
     logical, intent(in), optional :: proc_in
 
     real, allocatable :: g_dat(:,:,:)
-    integer :: p
     integer :: isd_p, ied_p, jsd_p, jed_p
     integer :: isg, ieg, jsg, jeg
     integer :: isc, iec, jsc, jec
@@ -2459,7 +2458,7 @@ contains
                             g_dat(isg:,jsg:,1), position=CENTER)
     endif
 
-    if(Atm(this_grid)%is_fine_pe .or. mpp_domain_is_tile_root_pe(Atm(this_grid)%parent_grid%domain)) then
+    if(Atm(this_grid)%BcastMember) then
       call mpp_broadcast(g_dat, size(g_dat),Atm(this_grid)%Bcast_ranks(1), Atm(this_grid)%Bcast_ranks)
     endif
 
@@ -2470,7 +2469,6 @@ contains
                             0, 0, isg, ieg, jsg, jeg, Atm(this_grid)%bd)
     endif
     deallocate(g_dat)
-    !deallocate(global_pelist)
 
   end subroutine fill_nested_grid_cpl
 

--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -168,7 +168,7 @@ use mpp_mod,                only: mpp_error, stdout, FATAL, WARNING, NOTE, &
                                   mpp_sync, mpp_sync_self, mpp_send, mpp_recv, mpp_broadcast
 use mpp_parameter_mod,      only: EUPDATE, WUPDATE, SUPDATE, NUPDATE
 use mpp_domains_mod,        only: CENTER, CORNER, NORTH, EAST, WEST, SOUTH
-use mpp_domains_mod,        only: domain2d, mpp_update_domains, mpp_global_field, mpp_domain_is_tile_root_pe
+use mpp_domains_mod,        only: domain2d, mpp_update_domains, mpp_global_field
 use mpp_domains_mod,        only: mpp_get_data_domain, mpp_get_compute_domain, mpp_get_global_domain
 use xgrid_mod,              only: grid_box_type
 use field_manager_mod,      only: MODEL_ATMOS

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1853,7 +1853,7 @@ contains
     implicit none
     type(fv_atmos_type), intent(INOUT) :: Atm
 
-    integer :: n,ierr
+    integer :: n
 
     if (.not.Atm%allocated) return
     deallocate (    Atm%u )

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1302,6 +1302,11 @@ module fv_arrays_mod
 
      integer, allocatable, dimension(:) :: pelist
 
+    ! These are set in fv_control_init() and used in fill_nested_grid_cpl()
+    ! to replace numerous p2p MPI transfers with a single MPI_Bcast
+    integer, allocatable :: Bcast_ranks(:)
+    integer :: Bcast_comm, sending_proc
+
      type(fv_grid_bounds_type) :: bd
 
     type(fv_regional_bc_bounds_type) :: regional_bc_bounds

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1305,7 +1305,6 @@ module fv_arrays_mod
     ! These are set in fv_control_init() and used in fill_nested_grid_cpl()
     ! to replace numerous p2p MPI transfers with a single mpp_broadcast()
     integer, allocatable :: Bcast_ranks(:)
-    integer :: Bcast_comm, sending_proc
     logical :: is_fine_pe
 
      type(fv_grid_bounds_type) :: bd

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1848,11 +1848,12 @@ contains
 
 !>@brief The subroutine 'deallocate_fv_atmos_type' deallocates the fv_atmos_type.
   subroutine deallocate_fv_atmos_type(Atm)
+    use mpi
 
     implicit none
     type(fv_atmos_type), intent(INOUT) :: Atm
 
-    integer :: n
+    integer :: n,ierr
 
     if (.not.Atm%allocated) return
     deallocate (    Atm%u )
@@ -2068,7 +2069,8 @@ contains
           call deallocate_fv_nest_BC_type(Atm%neststruct%delz_BC)
        endif
 #endif
-
+       if(allocated(Atm%Bcast_ranks)) deallocate(Atm%Bcast_ranks)
+       if(Atm%Bcast_comm /= MPI_COMM_NULL) call MPI_Comm_free(Atm%Bcast_comm,ierr)
     end if
 
     if (Atm%flagstruct%grid_type < 4) then

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1306,6 +1306,7 @@ module fv_arrays_mod
     ! to replace numerous p2p MPI transfers with a single mpp_broadcast()
     integer, allocatable :: Bcast_ranks(:)
     integer :: Bcast_comm, sending_proc
+    logical :: is_fine_pe
 
      type(fv_grid_bounds_type) :: bd
 

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1848,7 +1848,6 @@ contains
 
 !>@brief The subroutine 'deallocate_fv_atmos_type' deallocates the fv_atmos_type.
   subroutine deallocate_fv_atmos_type(Atm)
-    use mpi
 
     implicit none
     type(fv_atmos_type), intent(INOUT) :: Atm

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1305,7 +1305,7 @@ module fv_arrays_mod
     ! These are set in fv_control_init() and used in fill_nested_grid_cpl()
     ! to replace numerous p2p MPI transfers with a single mpp_broadcast()
     integer, allocatable :: Bcast_ranks(:)
-    logical :: is_fine_pe
+    logical :: BcastMember
 
      type(fv_grid_bounds_type) :: bd
 

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1303,7 +1303,7 @@ module fv_arrays_mod
      integer, allocatable, dimension(:) :: pelist
 
     ! These are set in fv_control_init() and used in fill_nested_grid_cpl()
-    ! to replace numerous p2p MPI transfers with a single MPI_Bcast
+    ! to replace numerous p2p MPI transfers with a single mpp_broadcast()
     integer, allocatable :: Bcast_ranks(:)
     integer :: Bcast_comm, sending_proc
 
@@ -2070,7 +2070,6 @@ contains
        endif
 #endif
        if(allocated(Atm%Bcast_ranks)) deallocate(Atm%Bcast_ranks)
-       if(Atm%Bcast_comm /= MPI_COMM_NULL) call MPI_Comm_free(Atm%Bcast_comm,ierr)
     end if
 
     if (Atm%flagstruct%grid_type < 4) then

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -744,8 +744,12 @@ module fv_control_mod
                        Atm(n)%parent_grid%flagstruct%ntiles-1 )*Atm(n)%parent_grid%npes_per_tile
 
           Atm(n)%Bcast_ranks(2:(1+size(Atm(n)%pelist)))=Atm(n)%pelist ! Receivers
+          Atm(n)%BcastMember=.false.
+          if(any(mpp_pe() == Atm(n)%Bcast_ranks)) then
+            Atm(n)%BcastMember=.true.
+          endif
+
           call mpp_declare_pelist(Atm(n)%Bcast_ranks(:))
-          Atm(n)%is_fine_pe = mpp_is_nest_fine(global_nest_domain, 1)
        enddo
        call mpp_set_current_pelist(Atm(this_grid)%pelist)
      endif

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -737,12 +737,12 @@ module fv_control_mod
        call mpp_set_current_pelist( global_pelist )
        do n=2,ngrids
         ! Construct the MPI communicators that are used in fill_nested_grid_cpl()
-          Atm(n)%sending_proc = Atm(n)%parent_grid%pelist(1) + &
+          allocate(Atm(n)%Bcast_ranks(1+size(Atm(n)%pelist)))
+          ! parent grid sending rank within Bcast_ranks array
+          Atm(n)%Bcast_ranks(1)=Atm(n)%parent_grid%pelist(1) + &
                      ( Atm(n)%neststruct%parent_tile-tile_fine(Atm(n)%parent_grid%grid_number)+ &
                        Atm(n)%parent_grid%flagstruct%ntiles-1 )*Atm(n)%parent_grid%npes_per_tile
-          allocate(Atm(n)%Bcast_ranks(1+size(Atm(n)%pelist)))
 
-          Atm(n)%Bcast_ranks(1)=Atm(n)%sending_proc ! parent grid sending rank within the soon to be created Bcast_comm
           Atm(n)%Bcast_ranks(2:(1+size(Atm(n)%pelist)))=Atm(n)%pelist ! Receivers
           call mpp_declare_pelist(Atm(n)%Bcast_ranks(:))
           Atm(n)%is_fine_pe = mpp_is_nest_fine(global_nest_domain, 1)

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -456,9 +456,9 @@ module fv_control_mod
      allocate(global_pelist(npes))
      call mpp_get_current_pelist(global_pelist, commID=global_commID) ! for commID
 
+     ! Need the fcst_mpi_comm in order to construct the communicators used by MPI_Bcast in fill_nested_grid_cpl()
      call ESMF_VMGetCurrent(vm=vm,rc=rc)
      call ESMF_VMGet(vm=vm, mpiCommunicator=fcst_mpi_comm, rc=rc)
-
 
      allocate(grids_master_procs(ngrids))
      pecounter = 0

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -144,7 +144,7 @@ module fv_control_mod
    use test_cases_mod,      only: read_namelist_test_case_nml
    use fv_timing_mod,       only: timing_on, timing_off, timing_init, timing_prt
    use mpp_domains_mod,     only: domain2D
-   use mpp_domains_mod,     only: mpp_define_nest_domains, nest_domain_type, mpp_get_global_domain, mpp_is_nest_fine
+   use mpp_domains_mod,     only: mpp_define_nest_domains, nest_domain_type, mpp_get_global_domain
    use mpp_domains_mod,     only: mpp_get_C2F_index, mpp_get_F2C_index
    use mpp_domains_mod,     only: CENTER, CORNER, NORTH, EAST, WEST, SOUTH
    use mpp_mod,             only: mpp_send, mpp_sync, mpp_transmit, mpp_set_current_pelist, &

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -188,6 +188,10 @@ module fv_control_mod
 
    subroutine fv_control_init(Atm, dt_atmos, this_grid, grids_on_this_pe, p_split, &
                               nml_filename_in, skip_nml_read_in)
+     use mpi
+     use esmf
+     integer :: fcst_mpi_comm, color, ierr, rc
+     type(ESMF_VM) :: vm
 
      type(fv_atmos_type), allocatable, intent(inout), target :: Atm(:)
      real,                intent(in)    :: dt_atmos
@@ -452,6 +456,9 @@ module fv_control_mod
      allocate(global_pelist(npes))
      call mpp_get_current_pelist(global_pelist, commID=global_commID) ! for commID
 
+     call ESMF_VMGetCurrent(vm=vm,rc=rc)
+     call ESMF_VMGet(vm=vm, mpiCommunicator=fcst_mpi_comm, rc=rc)
+
 
      allocate(grids_master_procs(ngrids))
      pecounter = 0
@@ -674,6 +681,22 @@ module fv_control_mod
         tile_id = mpp_get_tile_id(Atm(n)%domain)
         Atm(n)%global_tile = tile_id(1) ! only meaningful locally
         Atm(n)%npes_per_tile = size(Atm(n)%pelist)/Atm(n)%flagstruct%ntiles ! domain decomp doesn't set this globally
+
+        ! Construct the MPI communicators that are used in fill_nested_grid_cpl()
+        if(n>1) then
+          Atm(n)%sending_proc = Atm(n)%parent_grid%pelist(1) + &
+                     ( Atm(n)%neststruct%parent_tile-tile_fine(Atm(n)%parent_grid%grid_number)+ &
+                       Atm(n)%parent_grid%flagstruct%ntiles-1 )*Atm(n)%parent_grid%npes_per_tile
+          allocate(Atm(n)%Bcast_ranks(0:size(Atm(n)%pelist)))
+
+          Atm(n)%Bcast_ranks(0)=Atm(n)%sending_proc ! parent grid sending rank within the soon to be created Bcast_comm
+          Atm(n)%Bcast_ranks(1:size(Atm(n)%pelist))=Atm(n)%pelist ! Receivers
+
+          color=0
+          if(any(mpp_pe() == Atm(n)%Bcast_ranks)) color=1
+          call MPI_Comm_split(fcst_mpi_comm, color, mpp_pe(), Atm(n)%Bcast_comm, ierr)
+          if(ierr /= MPI_SUCCESS) print*,'fv_control_init: MPI_Comm_split',n,ierr
+        endif
      enddo
 
      ! 6. Set up domain and Atm structure

--- a/model/molecular_diffusion.F90
+++ b/model/molecular_diffusion.F90
@@ -41,7 +41,7 @@ module molecular_diffusion_mod
       use constants_mod,      only: rdgas, cp_air
       use fv_mp_mod,          only: is_master
       use mpp_mod,            only: stdlog, input_nml_file
-      use fms_mod,            only: check_nml_error, open_namelist_file, close_file
+      use fms_mod,            only: check_nml_error
       use fv_grid_utils_mod,  only: g_sum
       use mpp_domains_mod,    only: domain2d
       use fv_arrays_mod,      only: fv_grid_type, fv_grid_bounds_type
@@ -128,20 +128,10 @@ module molecular_diffusion_mod
 
       unit = stdlog()
 
-#ifdef INTERNAL_FILE_NML
-
       ! Read molecular_diffusion namelist
-        read (input_nml_file,molecular_diffusion_nml,iostat=ios)
-        ierr = check_nml_error(ios,'molecular_diffusion_nml')
+      read (input_nml_file,molecular_diffusion_nml,iostat=ios)
+      ierr = check_nml_error(ios,'molecular_diffusion_nml')
 
-#else
-      ! Read molecular_diffusion namelist
-        f_unit = open_namelist_file(nml_filename)
-        rewind (f_unit)
-        read (f_unit,molecular_diffusion_nml,iostat=ios)
-        ierr = check_nml_error(ios,'molecular_diffusion_nml')
-        call close_file(f_unit)
-#endif
       write(unit, nml=molecular_diffusion_nml)
       call molecular_diffusion_init(ncnst,nwat)
 

--- a/model/multi_gases.F90
+++ b/model/multi_gases.F90
@@ -42,7 +42,7 @@ module multi_gases_mod
       use constants_mod,     only: rdgas, rvgas, cp_air
       use     fv_mp_mod,     only: is_master
       use mpp_mod,           only: stdlog, input_nml_file
-      use fms_mod,           only: check_nml_error, open_namelist_file, close_file
+      use fms_mod,           only: check_nml_error
 
 
       implicit none
@@ -154,25 +154,15 @@ module multi_gases_mod
        ri(1)  = rvgas
        cpi(0) = cp_air
        cpi(1) = 4*cp_air
-#ifdef INTERNAL_FILE_NML
 
-      ! Read multi_gases namelist
-        read (input_nml_file,multi_gases_nml,iostat=ios)
-        ierr = check_nml_error(ios,'multi_gases_nml')
+       ! Read multi_gases namelist
+       read (input_nml_file,multi_gases_nml,iostat=ios)
+       ierr = check_nml_error(ios,'multi_gases_nml')
 
-#else
-      ! Read multi_gases namelist
-        f_unit = open_namelist_file(nml_filename)
+       write(unit, nml=multi_gases_nml)
+       call multi_gases_init(ncnst,nwat)
 
-        rewind (f_unit)
-        read (f_unit,multi_gases_nml,iostat=ios)
-        ierr = check_nml_error(ios,'multi_gases_nml')
-        call close_file(f_unit)
-#endif
-      write(unit, nml=multi_gases_nml)
-      call multi_gases_init(ncnst,nwat)
-
-      return
+       return
       end subroutine read_namelist_multi_gases_nml
 
 

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -148,7 +148,7 @@ module fv_grid_tools_mod
   use fms2_io_mod,       only: file_exists, variable_exists, open_file, read_data, &
                                get_global_attribute, get_variable_attribute, &
                                close_file, get_mosaic_tile_grid, FmsNetcdfFile_t
-  use mosaic_mod,        only: get_mosaic_ntiles
+  use mosaic2_mod,        only: get_mosaic_ntiles
 
   implicit none
   private
@@ -227,6 +227,11 @@ contains
 
     call get_mosaic_tile_grid(atm_hgrid, atm_mosaic, Atm%domain)
 
+    if (open_file(Grid_input, atm_mosaic, "read")) then
+       ntiles = get_mosaic_ntiles(Grid_input)
+       call close_file(Grid_input)
+    endif
+
     grid_form = "none"
     if (open_file(Grid_input, atm_hgrid, "read")) then
        call get_global_attribute(Grid_input, "history", attvalue)
@@ -234,7 +239,6 @@ contains
     if(grid_form .NE. "gnomonic_ed") call mpp_error(FATAL, &
          "fv_grid_tools(read_grid): the grid should be 'gnomonic_ed' when reading from grid file, contact developer")
 
-    ntiles = get_mosaic_ntiles(atm_mosaic)
     if( .not. Atm%gridstruct%bounded_domain) then  !<-- The regional setup has only 1 tile so do not shutdown in that case.
        if(ntiles .NE. 6) call mpp_error(FATAL, &
             'fv_grid_tools(read_grid): ntiles should be 6 in mosaic file '//trim(atm_mosaic) )

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -37,7 +37,7 @@
 
 module fv_iau_mod
 
-  use fms_mod,             only: file_exist
+  use fms2_io_mod,         only: file_exists
   use mpp_mod,             only: mpp_error, FATAL, NOTE, mpp_pe
   use mpp_domains_mod,     only: domain2d
 
@@ -186,7 +186,7 @@ subroutine IAU_initialize (IPD_Control, IAU_Data,Init_parm)
     npz = IPD_Control%levs
     fname = 'INPUT/'//trim(IPD_Control%iau_inc_files(1))
 
-    if( file_exist(fname) ) then
+    if( file_exists(fname) ) then
       call open_ncfile( fname, ncid )        ! open the file
       call get_ncdim1( ncid, 'lon',   im)
       call get_ncdim1( ncid, 'lat',   jm)
@@ -457,7 +457,7 @@ subroutine read_iau_forcing(IPD_Control,increments,fname)
 
     npz = IPD_Control%levs
 
-    if( file_exist(fname) ) then
+    if( file_exists(fname) ) then
       call open_ncfile( fname, ncid )        ! open the file
     else
       call mpp_error(FATAL,'==> Error in read_iau_forcing: Expected file '&

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -168,7 +168,6 @@ module fv_restart_mod
   use mpp_domains_mod,     only: mpp_global_field
   use fv_treat_da_inc_mod, only: read_da_inc
   use fms2_io_mod,         only: file_exists, set_filename_appendix, FmsNetcdfFile_t, open_file, close_file
-  use fms_io_mod,          only: fmsset_filename_appendix=> set_filename_appendix
   use coarse_grained_restart_files_mod, only: fv_io_write_restart_coarse
   use fv_regional_mod,     only: write_full_fields
 #ifdef MULTI_GASES
@@ -289,7 +288,6 @@ contains
        if (Atm(n)%neststruct%nested .and. n==this_grid) then
           write(gnn,'(A4, I2.2)') "nest", Atm(n)%grid_number
           call set_filename_appendix(gnn)
-          call fmsset_filename_appendix(gnn)
        endif
 
        !3preN. Topography BCs for nest, including setup for blending

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -117,7 +117,7 @@
 
       use mpp_mod,           only: mpp_error, FATAL, mpp_root_pe, mpp_broadcast, mpp_sum
       use mpp_mod,           only: stdlog, input_nml_file
-      use fms_mod,           only: check_nml_error, close_file, open_namelist_file
+      use fms_mod,           only: check_nml_error
       use mpp_domains_mod,   only: mpp_update_domains, domain2d
       use mpp_parameter_mod, only: AGRID_PARAM=>AGRID,CGRID_NE_PARAM=>CGRID_NE, &
                                    SCALAR_PAIR


### PR DESCRIPTION
Performance profiling of a HAFS case on NOAA systems revealed significant of time was spent in fill_nested_grid_cpl().  The fill_nested_grid_cpl() routine from FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90 is showing up as a performance bottleneck.  This routine gathers a global SST field (6,336,000 bytes) onto rank 0, then broadcasts that field to all ranks in the nest.  The code uses point-to-point (p2p) messages (Isend/Recv) from rank 0 to the nest ranks.  This communication pattern is maxing out the SlingShot-10 link on the first node resulting in a .15s hit every fifth time step.  This works out to 189 seconds for a full 5-day simulation.  These timings are from the 26 node HAFS case on acorn.

Given the way its currently coded coded, I expect the bottleneck to grow with the number of ranks in the nest.  Timings from a 47-node production case run for 24-hour simulation on cactus with and without using the code changes contained in this PR.

An offline reproducer showed that setting the following environment variables improved the performance of using MPI_Bcast in this scenario.

export MPICH_BCAST_ONLY_TREE=0
export MPICH_COLL_OPT_OFF=mpi_bcast

Scenarios:
1. Unmodified code (Baseline)
2. Unmodified code with above environment settings
3. Code modified following this PR with environment settings
4. Code modified to use MPI_Bcast directly with above environment settings
5. Code modified  to use MPI_Bcast directly without environment settings

Performance metric:
Add up the phase1 and phase2 timings printed in the output listing
grep PASS stdout | awk '{t+=$10;print t}' | tail -1
The units are seconds.

|   Scenario  |   Trial1    |    Trial2   |   Trial3   |   Trial4   |   Trial5   |   Trial6   | Mean | 
| -------------- | ------------ | ----------- |-------------- | ------------ | ----------- |----------- |----------- |
| 1 |  966.2  |  960.9 |
| 2 |  964.9  |  966.9 | 986.6 | 976.4 | x | x | 973.7 |
| 3 |  971.3  | 955.8 |  934.4 | 941.6 | 944.8 | 936.7 | 947.4 |
| 4 |  899.3  | 896.5 | 915.6  | 911.3 | 909.6 | 912.0 | 907.3 |
| 5 |  895.1  | 899.9 |

Based on these timings, I expect savings from scenario 3 (this PR) of ~(26s)*5=131 seconds for a full 5-day simulation.
Based on these timings, I expect savings from scenario 4 (previous version of this PR) of ~(66s)*5=332 seconds for a full 5-day simulation.

This PR does not address any open issues.

I ran the UFS regression suite on acorn and cactus.  Both runs resulted in "REGRESSION TEST WAS SUCCESSFUL"

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
