### PR TITLE
Unify the missing value in physics and dynamics

### DIFF
--- a/driver/fvGFS/fv_nggps_diag.F90
+++ b/driver/fvGFS/fv_nggps_diag.F90
@@ -103,7 +103,7 @@ module fv_nggps_diags_mod
  implicit none
  private
 
- real, parameter:: missing_value = -1.e10
+ real, parameter:: missing_value = 9.99e20
  real, parameter:: stndrd_atmos_ps = 101325.
  real, parameter:: stndrd_atmos_lapse = 0.0065
 


### PR DESCRIPTION
**Description**

Current UFS history file outputs use different missing values (FillValue) in atmosphere 3D field files and the surface files. In order to unify the inline post processing interfaces, we need to update history files to use a unified missing value in the history files for the UFS applications..

Fixes # (issue)
Change the missing value of the standard one used by POST, it is also used in the GFS physics.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
