### PR TITLE
Write netcdf axis variables using the same real kind as data variables

### DIFF
--- a/driver/fvGFS/fv_ufs_restart_io.F90
+++ b/driver/fvGFS/fv_ufs_restart_io.F90
@@ -435,7 +435,7 @@ module fv_ufs_restart_io_mod
    character(len=*), intent(in)    :: axis_name
    integer,          intent(in)    :: num_levels
 
-   real(8), allocatable, dimension(:) :: buffer
+   real, allocatable, dimension(:) :: buffer
    integer :: rc, i
 
    call ESMF_AttributeAdd(field, convention="NetCDF", purpose="FV3", &
@@ -485,6 +485,12 @@ module fv_ufs_restart_io_mod
    character(len=8), dimension(2)  :: dim_names_2d
    integer :: j
 
+#ifdef OVERLOAD_R4
+   character(len=5), parameter :: axis_type = 'float'
+#else
+   character(len=6), parameter :: axis_type = 'double'
+#endif
+
    dim_names_2d(1) = "xaxis_1"
    dim_names_2d(2) = "Time"
 
@@ -501,7 +507,7 @@ module fv_ufs_restart_io_mod
 
    call register_axis(Fv_restart, "xaxis_1", size(Atm%ak(:), 1))
    call register_axis(Fv_restart, "Time", unlimited)
-   call register_field(Fv_restart, "xaxis_1", "double", (/"xaxis_1"/))
+   call register_field(Fv_restart, "xaxis_1", axis_type, (/"xaxis_1"/))
    call register_variable_attribute(Fv_restart,"xaxis_1", "axis", "X", str_len=1)
    if (allocated(buffer)) deallocate(buffer)
    allocate(buffer(size(Atm%ak(:), 1)))
@@ -510,7 +516,7 @@ module fv_ufs_restart_io_mod
    end do
    call write_data(Fv_restart, "xaxis_1", buffer)
    deallocate(buffer)
-   call register_field(Fv_restart, "Time", "double", (/"Time"/))
+   call register_field(Fv_restart, "Time", axis_type, (/"Time"/))
    call register_variable_attribute(Fv_restart, dim_names_2d(2), "cartesian_axis", "T", str_len=1)
    call register_variable_attribute(Fv_restart, dim_names_2d(2), "units", "time level", str_len=len("time level"))
    call register_variable_attribute(Fv_restart, dim_names_2d(2), "long_name", dim_names_2d(2), str_len=len(dim_names_2d(2)))

--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -126,6 +126,12 @@ module fv_io_mod
   integer ::grid_xtdimid, grid_ytdimid, haloid, pfullid !For writing BCs
   integer ::grid_xtstagdimid, grid_ytstagdimid, oneid
 
+#ifdef OVERLOAD_R4
+  character(len=5), parameter :: axis_type = 'float'
+#else
+  character(len=6), parameter :: axis_type = 'double'
+#endif
+
 contains
 
 
@@ -163,7 +169,7 @@ contains
       axisname = 'xaxis_'//suffix
       call register_axis(file_obj, axisname, 'X', domain_position=xpos(i))
       if (.not. file_obj%is_readonly) then !if writing file
-        call register_field(file_obj, axisname, "double", (/axisname/))
+        call register_field(file_obj, axisname, axis_type, (/axisname/))
         call register_variable_attribute(file_obj,axisname, "axis", "X", str_len=1)
         call get_global_io_domain_indices(file_obj, axisname, is, ie, buffer)
         call write_data(file_obj, axisname, buffer)
@@ -177,7 +183,7 @@ contains
       axisname = 'yaxis_'//suffix
       call register_axis(file_obj, axisname, 'Y', domain_position=ypos(i))
       if (.not. file_obj%is_readonly) then !if writing file
-        call register_field(file_obj, axisname, "double", (/axisname/))
+        call register_field(file_obj, axisname, axis_type, (/axisname/))
         call register_variable_attribute(file_obj,axisname, "axis", "Y", str_len=1)
         call get_global_io_domain_indices(file_obj, axisname, is, ie, buffer)
         call write_data(file_obj, axisname, buffer)
@@ -191,7 +197,7 @@ contains
         axisname = 'zaxis_'//suffix
         call register_axis(file_obj, axisname, zsize(i))
         if (.not. file_obj%is_readonly) then !if writing file
-          call register_field(file_obj, axisname, "double", (/axisname/))
+          call register_field(file_obj, axisname, axis_type, (/axisname/))
           call register_variable_attribute(file_obj,axisname, "axis", "Z", str_len=1)
           if (allocated(buffer)) deallocate(buffer)
           allocate(buffer(zsize(i)))
@@ -206,7 +212,7 @@ contains
 
     call register_axis(file_obj, "Time", unlimited)
     if (.not. file_obj%is_readonly) then !if writing file
-       call register_field(file_obj, "Time", "double", (/"Time"/))
+       call register_field(file_obj, "Time", axis_type, (/"Time"/))
        call register_variable_attribute(file_obj, "Time", "cartesian_axis", "T", str_len=1)
        call register_variable_attribute(file_obj, "Time", "units", "time level", &
                                         str_len=len("time level"))
@@ -307,7 +313,7 @@ contains
        call register_axis(Atm%Fv_restart, "xaxis_1", size(Atm%ak(:), 1))
        call register_axis(Atm%Fv_restart, "Time", unlimited)
        if (.not. Atm%Fv_restart%is_readonly) then !if writing file
-          call register_field(Atm%Fv_restart, "xaxis_1", "double", (/"xaxis_1"/))
+          call register_field(Atm%Fv_restart, "xaxis_1", axis_type, (/"xaxis_1"/))
           call register_variable_attribute(Atm%Fv_restart,"xaxis_1", "axis", "X", str_len=1)
           if (allocated(buffer)) deallocate(buffer)
           allocate(buffer(size(Atm%ak(:), 1)))
@@ -316,7 +322,7 @@ contains
           end do
           call write_data(Atm%Fv_restart, "xaxis_1", buffer)
           deallocate(buffer)
-          call register_field(Atm%Fv_restart, "Time", "double", (/"Time"/))
+          call register_field(Atm%Fv_restart, "Time", axis_type, (/"Time"/))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(2), "cartesian_axis", "T", str_len=1)
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(2), "units", "time level", str_len=len("time level"))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(2), "long_name", dim_names_2d(2), str_len=len(dim_names_2d(2)))


### PR DESCRIPTION
**Description**

Currently, the axis data type in restart files is always "double" regardless of the data type (float vs. double) of used for data variables. This PR updates io routines so that axis data type corresponds to the actual precision used for data variables.
This change is necessary to make restart files bit-identical to the restart files written out by the write grid component in UFS weather model.

Fixes # (issue)
https://github.com/NOAA-EMC/fv3atm/issues/696

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

Full regression test of the ufs weather model passed on Hera (both Intel and GNU compilers) and Orion. 


**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
