### PR TITLE
tools/fv_io: fix a few minor errors

### DIFF
--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -729,8 +729,9 @@ contains
           call read_restart(Atm(1)%Rsf_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
           call close_file(Atm(1)%Rsf_restart)
           Atm(1)%Rsf_restart_is_open = .false.
-         call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')
-         Atm%flagstruct%srf_init = .false.
+       else
+          call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')
+          Atm%flagstruct%srf_init = .false.
        endif
 
        if ( Atm(1)%flagstruct%fv_land ) then
@@ -740,6 +741,7 @@ contains
          if (Atm(1)%Mg_restart_is_open) then
             call read_data(Atm(1)%Mg_restart, 'ghprime', Atm(1)%sgh)
             call close_file(Atm(1)%Mg_restart)
+            Atm(1)%Mg_restart_is_open = .false.
          else
            call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')
          endif
@@ -749,6 +751,7 @@ contains
          if (Atm(1)%Lnd_restart_is_open) then
            call read_data(Atm(1)%Lnd_restart, 'oro', Atm(1)%oro)
            call close_file(Atm(1)%Lnd_restart)
+           Atm(1)%Lnd_restart_is_open = .false.
          else
            call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')
          endif
@@ -1463,11 +1466,13 @@ contains
     if (Atm%neststruct%BCfile_sw_is_open) then
       call write_restart_bc(Atm%neststruct%BCfile_sw)
       call close_file(Atm%neststruct%BCfile_sw)
+      Atm%neststruct%BCfile_sw_is_open = .false.
     endif
 
     if (Atm%neststruct%BCfile_ne_is_open) then
      call write_restart_bc(Atm%neststruct%BCfile_ne)
      call close_file(Atm%neststruct%BCfile_ne)
+     Atm%neststruct%BCfile_ne_is_open = .false.
     endif
 
     deallocate(all_pelist)
@@ -1497,11 +1502,13 @@ contains
     if (Atm%neststruct%BCfile_sw_is_open) then
       call read_restart_bc(Atm%neststruct%BCfile_sw, ignore_checksum=Atm%flagstruct%ignore_rst_cksum)
       call close_file(Atm%neststruct%BCfile_sw)
+      Atm%neststruct%BCfile_sw_is_open = .false.
     endif
 
     if (Atm%neststruct%BCfile_ne_is_open) then
      call read_restart_bc(Atm%neststruct%BCfile_ne, ignore_checksum=Atm%flagstruct%ignore_rst_cksum)
      call close_file(Atm%neststruct%BCfile_ne)
+     Atm%neststruct%BCfile_ne_is_open = .false.
     endif
 
 


### PR DESCRIPTION
**Description**

Adds missing else statement in fv_io.
Also noticed that some of the *_is_open variables (which should be set to false when closing the file) were not explicitly set to false.  So this also includes a few of these fixes.

Fixes #282 (this change needs to be pulled into dev/emc, dev/gfdl and dev/gfdl_am5)

**How Has This Been Tested?**

Tested on gaea C5 with SHiELD_build RTS and CI tests.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
