### PR TITLE
Create daily_cleanup_parallelworks.yaml

### DIFF
--- a/.github/workflows/SHiELD_parallelworks_intel.yml
+++ b/.github/workflows/SHiELD_parallelworks_intel.yml
@@ -27,7 +27,7 @@ jobs:
     # this is enough nodes for the first 17 tests to run in parallel, and we
     # have 17 runners configured.
     - run: salloc --partition=p2 -N 46 -J $GITHUB_REF sleep 20m &
-    - run: /contrib/fv3/intelFV3CIScripts/checkout.sh $GITHUB_REF
+    - run: /contrib/fv3/GFDL_atmos_cubed_sphere_CI/checkout.sh $GITHUB_REF
     
   build:
     runs-on: [self-hosted,devcimultiintel]
@@ -37,7 +37,7 @@ jobs:
       fail-fast: true
       max-parallel: 3
       matrix:
-        runpath: [/contrib/fv3/intelFV3CIScripts/]
+        runpath: [/contrib/fv3/GFDL_atmos_cubed_sphere_CI/]
         runscript: [swcompile.sh, nhcompile.sh, hydrocompile.sh]
     steps:
       - env:
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       max-parallel: 17
       matrix:
-        runpath: [/contrib/fv3/intelFV3CIScripts/]
+        runpath: [/contrib/fv3/GFDL_atmos_cubed_sphere_CI/]
         runscript:
           # These are placed in order of largest to smallest jobs
           #layout 8,8 needs 8 nodes on dvcimultiintel cluster

--- a/.github/workflows/daily_cleanup_parallelworks.yaml
+++ b/.github/workflows/daily_cleanup_parallelworks.yaml
@@ -14,4 +14,4 @@ jobs:
     runs-on: [self-hosted, devcimultiintel]
     name: Delete Builds
     steps:
-      - run: find /contrib/fv3/2023.2.0/refs/pull -maxdepth 1 -mindepth 1 -mtime +30 -type d -print -delete
+      - run: find /contrib/fv3/2023.2.0/GFDL_atmos_cubed_sphere/refs/pull -maxdepth 1 -mindepth 1 -mtime +30 -type d -print -delete

--- a/.github/workflows/daily_cleanup_parallelworks.yaml
+++ b/.github/workflows/daily_cleanup_parallelworks.yaml
@@ -1,0 +1,17 @@
+name: Old Build Cleanup
+
+# This GitHub Action Workflow is runing on the devcimultiintel cluster
+# This will delete all build directories older than 30 days
+# Build directories are on the cloud at /contrib/fv3/2023.2.0
+
+on:
+  schedule:
+    # run daily at midnight
+    - cron: '0 0 * * *'
+
+jobs:
+  delete:
+    runs-on: [self-hosted, devcimultiintel]
+    name: Delete Builds
+    steps:
+      - run: find /contrib/fv3/2023.2.0/refs/pull -maxdepth 1 -mindepth 1 -mtime +30 -type d -print -delete


### PR DESCRIPTION
**Description**

This will add a new GitHub Action Workflow File.  This is an automated action to cleanup old PR Build Dirs residing on the cloud as a result of CI runs on PRs.  I have arbitrarily chosen a 30 day retention of the PR CI build directories on the cloud.  Anything older than 30 days would be deleted by this automated workflow.  This will be scheduled to run every night at midnight UTC.  Please provide input if you would like me to change the 30 day window.

Fixes # (issue)

**How Has This Been Tested?**

I tested the command find /contrib/fv3/2023.2.0/refs/pull -maxdepth 1 -mindepth 1 -mtime +30 -type d -print -delete on the cluster.  This workflow will be fully tested when it has its first run tonight at midnight UTC.  

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
