### PR TITLE
Gzbugfix

### DIFF
--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -155,7 +155,7 @@ contains
   real, dimension(is:ie,km+1):: pe1, pe2, pk1, pk2, pn2, phis
   real, dimension(isd:ied,jsd:jed,km):: pe4
   real, dimension(is:ie+1,km+1):: pe0, pe3
-  real, dimension(is:ie):: gz, cvm
+  real, dimension(is:ie+1):: gz, cvm
   real, dimension(isd:ied,jsd:jed,km):: qnl, qni
 
   real rcp, rg, rrg, bkh, dtmp, k1k, dlnp, tpe
@@ -220,7 +220,7 @@ contains
                  do k=1,km
 #ifdef MOIST_CAPPA
                     call moist_cv(is,ie,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
-                         ice_wat, snowwat, graupel, q, gz, cvm)
+                         ice_wat, snowwat, graupel, q, gz(is:ie), cvm(is:ie))
                     do i=is,ie
                        q_con(i,j,k) = gz(i)
                        cappa(i,j,k) = rdgas / ( rdgas + cvm(i)/(1.+r_vir*q(i,j,k,sphum)) )
@@ -272,7 +272,7 @@ contains
                  enddo
 #ifdef MOIST_CAPPA
                  call moist_cv(is,ie,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
-                      ice_wat, snowwat, graupel, q, gz, cvm)
+                      ice_wat, snowwat, graupel, q, gz(is:ie), cvm(is:ie))
                  do i=is,ie
                     q_con(i,j,k) = gz(i)
                     cappa(i,j,k) = rdgas / ( rdgas + cvm(i)/(1.+r_vir*q(i,j,k,sphum)) )
@@ -366,7 +366,7 @@ contains
                  km,   pe2,  te,       &
                  is, ie, j, isd, ied, jsd, jed, akap, T_VAR=1, conserv=.true.)
          else
-            call map_scalar(km,  peln(is,1,j),  te, gz,   &
+            call map_scalar(km,  peln(is,1,j),  te, gz(is:ie),   &
                  km,  pn2,           te,              &
                  is, ie, j, isd, ied, jsd, jed, 1, abs(kord_tm), cp_air*t_min)
          endif
@@ -374,13 +374,13 @@ contains
       else
          if ( kord_tm<0 ) then
             ! Map t using logp
-            call map_scalar(km,  peln(is,1,j),  pt, gz,   &
+            call map_scalar(km,  peln(is,1,j),  pt, gz(is:ie),   &
                  km,  pn2,           pt,              &
                  is, ie, j, isd, ied, jsd, jed, &
                  1, abs(kord_tm), t_min)
          else
             ! Map pt using pe
-            call map1_ppm (km,  pe1,  pt,  gz,       &
+            call map1_ppm (km,  pe1,  pt,  gz(is:ie),       &
                  km,  pe2,  pt,                  &
                  is, ie, j, isd, ied, jsd, jed, &
                  1, abs(kord_tm))
@@ -423,7 +423,7 @@ contains
                  -2, abs(kord_wz))
          endif
          ! Remap delz for hybrid sigma-p coordinate
-         call map1_ppm (km,   pe1, delz,  gz,   & ! works
+         call map1_ppm (km,   pe1, delz,  gz(is:ie),   & ! works
               km,   pe2, delz,              &
               is, ie, j, is,  ie,  js,  je,  &
               1, abs(kord_tm))
@@ -527,8 +527,8 @@ contains
             ! Note: pt at this stage is T_v or T_m , unless kord_tm > 0
             do k=1,km
 #ifdef MOIST_CAPPA
-               call moist_cv(is,ie,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
-                    ice_wat, snowwat, graupel, q, gz, cvm)
+               call moist_cv(is,ie+1,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
+                    ice_wat, snowwat, graupel, q, gz(is:ie+1), cvm(is:ie+1))
                if ( kord_tm < 0 ) then
                   do i=is,ie
                      q_con(i,j,k) = gz(i)
@@ -613,7 +613,7 @@ contains
       enddo
    enddo
 
-   call map1_ppm( km, pe0(is:ie,:),   u,   gz,   &
+   call map1_ppm( km, pe0(is:ie,:),   u,   gz(is:ie),   &
                   km, pe3(is:ie,:),   u,               &
                   is, ie, j, isd, ied, jsd, jed+1, &
                   -1, kord_mt)
@@ -634,7 +634,7 @@ contains
          enddo
       enddo
 
-      call map1_ppm (km, pe0,  v, gz,    &
+      call map1_ppm (km, pe0,  v, gz(is:ie+1),    &
                      km, pe3,  v, is, ie+1,    &
                      j, isd, ied+1, jsd, jed, -1, kord_mt)
 
@@ -660,7 +660,7 @@ contains
             do k=km,1,-1
 #ifdef MOIST_CAPPA
                call moist_cv(is,ie,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
-                    ice_wat, snowwat, graupel, q, gz, cvm)
+                    ice_wat, snowwat, graupel, q, gz(is:ie), cvm(is:ie))
                do i=is,ie
                   q_con(i,j,k) = gz(i)
                   cappa(i,j,k) = rdgas / ( rdgas + cvm(i)/(1.+r_vir*q(i,j,k,sphum)) )
@@ -759,7 +759,7 @@ contains
                  do k=1,km
 #ifdef USE_COND
                     call moist_cv(is,ie,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
-                         ice_wat, snowwat, graupel, q, gz, cvm)
+                         ice_wat, snowwat, graupel, q, gz(is:ie), cvm(is:ie))
                     do i=is,ie
                        ! KE using 3D winds:
                        q_con(i,j,k) = gz(i)
@@ -870,7 +870,7 @@ contains
            else
 #ifdef USE_COND
               call moist_cv(is,ie,isd,ied,jsd,jed, km, j, k, nwat, sphum, liq_wat, rainwat,    &
-                   ice_wat, snowwat, graupel, q, gz, cvm)
+                   ice_wat, snowwat, graupel, q, gz(is:ie), cvm(is:ie))
               do i=is,ie
                  pt(i,j,k) = (pt(i,j,k)+dtmp/cvm(i)*pkz(i,j,k))/((1.+r_vir*q(i,j,k,sphum))*(1.-gz(i)))
               enddo


### PR DESCRIPTION
Description:

Increase the dimension of the local variable gz to have enough points needed when remapping v.
Adjust array bounds in the remapping routine and then compute the extra point only when it is needed from moist_cv before remapping v.

Fixes #70

**How Has This Been Tested?**

Tests were performed on Gaea with no answer change.
The modified code is affected with iv=-2 when calling map1_ppm. It works fine with iv=-2

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
