### PR TITLE
Diss est fix

### DIFF
--- a/model/sw_core.F90
+++ b/model/sw_core.F90
@@ -1439,7 +1439,7 @@ module sw_core_mod
 
    endif
 
-   if ( d_con > 1.e-5 ) then
+   if ( d_con > 1.e-5 .or. flagstruct%do_diss_est) then
       do j=js,je+1
          do i=is,ie
             ub(i,j) = vort(i,j) - vort(i+1,j)
@@ -1493,6 +1493,9 @@ module sw_core_mod
    if ( damp_v>1.E-5 ) then
         damp4 = (damp_v*gridstruct%da_min_c)**(nord_v+1)
         call del6_vt_flux(nord_v, npx, npy, damp4, wk, vort, ut, vt, gridstruct, bd)
+   elseif (flagstruct%do_diss_est) then
+        ut=0.
+        vt=0.
    endif
 
    if ( d_con > 1.e-5 .or. flagstruct%do_diss_est ) then


### PR DESCRIPTION
**Description**

This MR fixes two issues with dissipation heating that arise in the following cases:
1- diss_est in the whole domain when do_vort_damp=.F.: damp_v will not allow a correct computation of local arrays ut, vt computed by del6_vt_flux and needed for the calculation of diss_est
2- diss_est in the sponge layers when do_vort_damp=.T.: d_con_k=0 in the sponge layers (set just before calling d_sw for k=1,2,3), this will not allow a correct computation of ub, vb since there is one condition (d_con > 1.e-5). ub, vb are used later to compute diss_est

This code change will fix ub, vb, ut, vt needed for the calculation of dissipative heating diss_est

Fixes #294

**How Has This Been Tested?**

Idealized tests on Gaea

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
