### PR TITLE
Cherrypick PR283 from dev/emc to main

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -5823,7 +5823,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
         call register_global_attribute(fileobj, "jhalo_shift", halo )
         call register_global_attribute(fileobj,  "hstagger", stagname )
 
-        call register_field(fileobj, name, "double", dim_names_3d)
+        call register_field(fileobj, name, axis_type, dim_names_3d)
 
         call write_data(fileobj, name, glob_field)
 
@@ -5935,7 +5935,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
         call register_global_attribute(fileobj, "jhalo_shift", halo )
         call register_global_attribute(fileobj,  "hstagger", stagname )
 
-        call register_field(fileobj, name, "double", dim_names_3d)
+        call register_field(fileobj, name, axis_type, dim_names_3d)
 
         call write_data(fileobj, name, glob_field)
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -235,8 +235,10 @@ module fv_regional_mod
 
 #ifdef OVERLOAD_R4
       real, parameter:: real_snan=real(Z'FFBFFFFF')
+      character(len=5), parameter :: axis_type = 'float'
 #else
       real, parameter:: real_snan=real(Z'FFF7FFFFFFFFFFFF')
+      character(len=6), parameter :: axis_type = 'double'
 #endif
       real(kind=R_GRID), parameter:: dbl_snan=real(Z'FFF7FFFFFFFFFFFF',kind=R_GRID)
 
@@ -5785,7 +5787,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
     if (open_file(fileobj, fname, "overwrite", domain)) then
         call register_axis(fileobj, "grid_xt", nxg)
-        call register_field(fileobj, "grid_xt", "double", (/"grid_xt"/))
+        call register_field(fileobj, "grid_xt", axis_type, (/"grid_xt"/))
         call register_variable_attribute(fileobj, "grid_xt", "axis", "X", str_len=1)
         call register_variable_attribute(fileobj, "grid_xt", "units", "km", str_len=len("km"))
         call register_variable_attribute(fileobj, "grid_xt", "long_name", "X distance", str_len=len("X distance"))
@@ -5793,7 +5795,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
         call write_data(fileobj, "grid_xt", (/(i*1.0,i=1,nxg)/))
 
         call register_axis(fileobj, "grid_yt", nyg)
-        call register_field(fileobj, "grid_yt", "double", (/"grid_yt"/))
+        call register_field(fileobj, "grid_yt", axis_type, (/"grid_yt"/))
         call register_variable_attribute(fileobj, "grid_yt", "axis", "Y", str_len=1)
         call register_variable_attribute(fileobj, "grid_yt", "units", "km", str_len=len("km"))
         call register_variable_attribute(fileobj, "grid_yt", "long_name", "Y distance", str_len=len("Y distance"))
@@ -5801,7 +5803,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
         call write_data(fileobj, "grid_yt", (/(j*1.0,j=1,nyg)/))
 
         call register_axis(fileobj, "lev", nz)
-        call register_field(fileobj, "lev", "double", (/"lev"/))
+        call register_field(fileobj, "lev", axis_type, (/"lev"/))
         call register_variable_attribute(fileobj, "lev", "axis", "Z", str_len=1)
         call register_variable_attribute(fileobj, "lev", "units", "km", str_len=len("km"))
         call register_variable_attribute(fileobj, "lev", "long_name", "Z distance", str_len=len("Z distance"))
@@ -5904,7 +5906,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
     if (open_file(fileobj, fname, "overwrite", domain)) then
         call register_axis(fileobj, "grid_xt", nxg)
-        call register_field(fileobj, "grid_xt", "double", (/"grid_xt"/))
+        call register_field(fileobj, "grid_xt", axis_type, (/"grid_xt"/))
         call register_variable_attribute(fileobj, "grid_xt", "axis", "X", str_len=1)
         call register_variable_attribute(fileobj, "grid_xt", "units", "km", str_len=len("km"))
         call register_variable_attribute(fileobj, "grid_xt", "long_name", "X distance", str_len=len("X distance"))
@@ -5912,7 +5914,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
         call write_data(fileobj, "grid_xt", (/(i*1.0,i=1,nxg)/))
 
         call register_axis(fileobj, "grid_yt", nyg)
-        call register_field(fileobj, "grid_yt", "double", (/"grid_yt"/))
+        call register_field(fileobj, "grid_yt", axis_type, (/"grid_yt"/))
         call register_variable_attribute(fileobj, "grid_yt", "axis", "Y", str_len=1)
         call register_variable_attribute(fileobj, "grid_yt", "units", "km", str_len=len("km"))
         call register_variable_attribute(fileobj, "grid_yt", "long_name", "Y distance", str_len=len("Y distance"))

--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -77,6 +77,12 @@ module fv_io_mod
   integer ::grid_xtdimid, grid_ytdimid, haloid, pfullid !For writing BCs
   integer ::grid_xtstagdimid, grid_ytstagdimid, oneid
 
+#ifdef OVERLOAD_R4
+  character(len=5), parameter :: axis_type = 'float'
+#else
+  character(len=6), parameter :: axis_type = 'double'
+#endif
+
 contains
 
   !#####################################################################
@@ -128,7 +134,7 @@ contains
       axisname = 'xaxis_'//suffix
       call register_axis(file_obj, axisname, 'X', domain_position=xpos(i))
       if (.not. file_obj%is_readonly) then !if writing file
-        call register_field(file_obj, axisname, "double", (/axisname/))
+        call register_field(file_obj, axisname, axis_type, (/axisname/))
         call register_variable_attribute(file_obj,axisname, "long_name", axisname, str_len=len(axisname))
         call register_variable_attribute(file_obj,axisname, "units", "none", str_len=len("none"))
         call register_variable_attribute(file_obj,axisname, "cartesian_axis", "X", str_len=1)
@@ -144,7 +150,7 @@ contains
       axisname = 'yaxis_'//suffix
       call register_axis(file_obj, axisname, 'Y', domain_position=ypos(i))
       if (.not. file_obj%is_readonly) then !if writing file
-        call register_field(file_obj, axisname, "double", (/axisname/))
+        call register_field(file_obj, axisname, axis_type, (/axisname/))
         call register_variable_attribute(file_obj,axisname, "long_name", axisname, str_len=len(axisname))
         call register_variable_attribute(file_obj,axisname, "units", "none", str_len=len("none"))
         call register_variable_attribute(file_obj,axisname, "cartesian_axis", "Y", str_len=1)
@@ -160,7 +166,7 @@ contains
         axisname = 'zaxis_'//suffix
         call register_axis(file_obj, axisname, zsize(i))
         if (.not. file_obj%is_readonly) then !if writing file
-          call register_field(file_obj, axisname, "double", (/axisname/))
+          call register_field(file_obj, axisname, axis_type, (/axisname/))
           call register_variable_attribute(file_obj,axisname, "long_name", axisname, str_len=len(axisname))
           call register_variable_attribute(file_obj,axisname, "units", "none", str_len=len("none"))
           call register_variable_attribute(file_obj,axisname, "cartesian_axis", "Z", str_len=1)
@@ -177,7 +183,7 @@ contains
 
     call register_axis(file_obj, "Time", unlimited)
     if (.not. file_obj%is_readonly) then !if writing file
-       call register_field(file_obj, "Time", "double", (/"Time"/))
+       call register_field(file_obj, "Time", axis_type, (/"Time"/))
        call register_variable_attribute(file_obj, "Time", "long_name", "Time", &
                                         str_len=len("Time"))
        call register_variable_attribute(file_obj, "Time", "units", "time level", &
@@ -244,7 +250,7 @@ contains
        call register_axis(Atm%Fv_restart, "xaxis_1", size(Atm%ak(:), 1))
        call register_axis(Atm%Fv_restart, "Time", unlimited)
        if (.not. Atm%Fv_restart%is_readonly) then !if writing file
-          call register_field(Atm%Fv_restart, dim_names_2d(1), "double", (/dim_names_2d(1)/))
+          call register_field(Atm%Fv_restart, dim_names_2d(1), axis_type, (/dim_names_2d(1)/))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(1), "long_name", dim_names_2d(1), str_len=len(dim_names_2d(1)))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(1), "units", "none", str_len=len("none"))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(1), "cartesian_axis", "X", str_len=1)
@@ -255,7 +261,7 @@ contains
           end do
           call write_data(Atm%Fv_restart, dim_names_2d(1), buffer)
           deallocate(buffer)
-          call register_field(Atm%Fv_restart, dim_names_2d(2), "double", (/dim_names_2d(2)/))
+          call register_field(Atm%Fv_restart, dim_names_2d(2), axis_type, (/dim_names_2d(2)/))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(2), "long_name", dim_names_2d(2), str_len=len(dim_names_2d(2)))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(2), "units", "time level", str_len=len("time level"))
           call register_variable_attribute(Atm%Fv_restart, dim_names_2d(2), "cartesian_axis", "T", str_len=1)


### PR DESCRIPTION
**Description**

When cherry-picking the changes from PR #283 I noticed that `model/fv_regional_bc.F90` should also be modified to have an axis type matching the precision that the dycore is built with and not hard-coded double precision.

Fixes # (issue)

**How Has This Been Tested?**

Tested with SHiELD on Gaea

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
