### PR TITLE
Modify external_sst

### DIFF
--- a/tools/external_sst.F90
+++ b/tools/external_sst.F90
@@ -21,8 +21,9 @@
 
 module external_sst_mod
 
-real, allocatable, dimension(:,:) ::  sst_ncep, sst_anom
 use amip_interp_mod, only: i_sst, j_sst, forecast_mode, use_ncep_sst
+
+real, allocatable, dimension(:,:) ::  sst_ncep, sst_anom
 
 public i_sst, j_sst, sst_ncep, sst_anom, forecast_mode, use_ncep_sst
 

--- a/tools/external_sst.F90
+++ b/tools/external_sst.F90
@@ -21,17 +21,8 @@
 
 module external_sst_mod
 
-#ifdef NO_GFDL_SHARED
-!----------------- Public Data -----------------------------------
-integer :: i_sst = -1
-integer :: j_sst = -1
-logical :: forecast_mode = .false.
-logical :: use_ncep_sst  = .false.
 real, allocatable, dimension(:,:) ::  sst_ncep, sst_anom
-#else
-use amip_interp_mod, only: i_sst, j_sst, sst_ncep, sst_anom, &
-                           forecast_mode, use_ncep_sst
-#endif
+use amip_interp_mod, only: i_sst, j_sst, forecast_mode, use_ncep_sst
 
 public i_sst, j_sst, sst_ncep, sst_anom, forecast_mode, use_ncep_sst
 


### PR DESCRIPTION
**Description**

FMS 2023.03 contains mixed precision support and had modified the types of sst_ncep and sst_anom to be hard-coded real8 in amip_interp_mod, which would have required updating some code in this repository when we reference sst_ncep and sst_anom in subroutines (such as pmaxmin).  
In testing this tag of FMS, we noticed that these variables do not need to come from amip_interp_mod as we allocate them within the dycore.  FMS will be updated to no longer declare sst_ncep and sst_anom(see issue: https://github.com/NOAA-GFDL/FMS/issues/1393), and this PR fixes the use statement so that we do not use the amip_interp_mod sst_ncep and sst_anom.  We also removed the `#ifdef NO_GFDL_SHARED` as this is not needed as we will always be compiling the sycore with FMS.

Fixes # (issue)

**How Has This Been Tested?**

Tested with FMS2023.03 with the SHiELD CI and RTS tests

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
