### PR TITLE
replacing the NO_QUAD_PRECISION macro with ENABLE_QUAD_PRECISION

### DIFF
--- a/model/fv_grid_utils.F90
+++ b/model/fv_grid_utils.F90
@@ -42,12 +42,12 @@
  implicit none
  private
  logical:: symm_grid
-#ifdef NO_QUAD_PRECISION
-! 64-bit precision (kind=8)
- integer, parameter:: f_p = selected_real_kind(15)
-#else
+#ifdef ENABLE_QUAD_PRECISION
 ! Higher precision (kind=16) for grid geometrical factors:
  integer, parameter:: f_p = selected_real_kind(20)
+#else
+! 64-bit precision (kind=8)
+ integer, parameter:: f_p = selected_real_kind(15)
 #endif
  real, parameter::  big_number=1.d8
  real, parameter:: tiny_number=1.d-8


### PR DESCRIPTION
**Description**

FMS 2023.03 removed the NO_QUAD_PRECISION macro from fms_platforms.h.  We can use the ENABLE_QUAD_PRECISION macro as this is defined in fms_platform.h in previous FMS versions and was retained in FMS 2023.03.

Fixes # (issue)

**How Has This Been Tested?**

Testing with FMS2023.03 manually and the CI will test with FMS2023.02

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
