### PR TITLE
Needed for FMS2023.03: Quad Precision macro change

### DIFF
--- a/model/fv_grid_utils.F90
+++ b/model/fv_grid_utils.F90
@@ -94,12 +94,12 @@
  implicit none
  private
  logical:: symm_grid
-#ifdef NO_QUAD_PRECISION
-! 64-bit precision (kind=8)
- integer, parameter:: f_p = selected_real_kind(15)
-#else
+#ifdef ENABLE_QUAD_PRECISION
 ! Higher precision (kind=16) for grid geometrical factors:
  integer, parameter:: f_p = selected_real_kind(20)
+#else
+! 64-bit precision (kind=8)
+ integer, parameter:: f_p = selected_real_kind(15)
 #endif
  real, parameter::  big_number=1.d8
  real, parameter:: tiny_number=1.d-8


### PR DESCRIPTION
**Description**

In FMS 2023.03, macro definitions are cleaned up in `fms_platforms.h`. As part of the cleanup, the definition of the macro `NO_QUAD_PRECISION` is removed, and the dycore is the only component that still used this macro.  This PR replaces the use of the outdated `NO_QUAD_PRECISION`  with `ENABLE_QUAD_PRECISION`.  This update is backwards compatible and has been tested with GFDL models using both FMS 2023.02 and FMS 2023.03 (via testing tag 2023.03-beta1).

Fixes # (issue)

**How Has This Been Tested?**

We have tested with SHiELD model and need assistance testing with UFS weather model.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
