### PR TITLE
Update for AM5: turns off saturation adjustment in 2dz filter

### DIFF
--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -528,6 +528,7 @@ contains
       real, parameter:: ustar2 = 1.E-4
       real:: cv_air, xvir
       integer :: sphum, liq_wat, rainwat, snowwat, graupel, ice_wat, cld_amt
+      logical:: sat_adj = .false.
 
       cv_air = cp_air - rdgas ! = rdgas * (7/2-1) = 2.5*rdgas=717.68
         rk = cp_air/rdgas + 1.
@@ -570,7 +571,7 @@ contains
 !$OMP parallel do default(none) shared(im,is,ie,js,je,nq,kbot,qa,ta,sphum,ua,va,delp,peln,     &
 !$OMP                                  hydrostatic,pe,delz,g2,w,liq_wat,rainwat,ice_wat,  &
 !$OMP                                  snowwat,cv_air,m,graupel,pkz,rk,rz,fra,cld_amt,    &
-!$OMP                                  u_dt,rdt,v_dt,xvir,nwat)                 &
+!$OMP                                  u_dt,rdt,v_dt,xvir,nwat,sat_adj)                 &
 !$OMP                          private(kk,lcp2,icp2,tcp3,dh,dq,den,qs,qsw,dqsdt,qcon,q0, &
 !$OMP                                  t0,u0,v0,w0,h0,pm,gzh,tvm,tmp,cpm,cvm, q_liq,q_sol,&
 !$OMP                                  tv,gz,hd,te,ratio,pt1,pt2,tv1,tv2,ri_ref, ri,mc,km1)
@@ -876,7 +877,7 @@ contains
 !----------------------
 ! Saturation adjustment
 !----------------------
-  if ( nwat > 5 ) then
+  if ( nwat > 5 .and. sat_adj) then
     do k=1, kbot
       if ( hydrostatic ) then
         do i=is, ie

--- a/model/gfdl_mp.F90
+++ b/model/gfdl_mp.F90
@@ -657,16 +657,16 @@ subroutine gfdl_mp_end
     ! free up memory
     ! -----------------------------------------------------------------------
 
-    deallocate (table0)
-    deallocate (table1)
-    deallocate (table2)
-    deallocate (table3)
-    deallocate (table4)
-    deallocate (des0)
-    deallocate (des1)
-    deallocate (des2)
-    deallocate (des3)
-    deallocate (des4)
+    if (allocated (table0)) deallocate (table0)
+    if (allocated (table1)) deallocate (table1)
+    if (allocated (table2)) deallocate (table2)
+    if (allocated (table3)) deallocate (table3)
+    if (allocated (table4)) deallocate (table4)
+    if (allocated (des0)) deallocate (des0)
+    if (allocated (des1)) deallocate (des1)
+    if (allocated (des2)) deallocate (des2)
+    if (allocated (des3)) deallocate (des3)
+    if (allocated (des4)) deallocate (des4)
 
     tables_are_initialized = .false.
 
@@ -6940,17 +6940,17 @@ subroutine qs_init
 
     if (.not. tables_are_initialized) then
 
-        allocate (table0 (length))
-        allocate (table1 (length))
-        allocate (table2 (length))
-        allocate (table3 (length))
-        allocate (table4 (length))
+        if (.not. allocated (table0)) allocate (table0 (length))
+        if (.not. allocated (table1)) allocate (table1 (length))
+        if (.not. allocated (table2)) allocate (table2 (length))
+        if (.not. allocated (table3)) allocate (table3 (length))
+        if (.not. allocated (table4)) allocate (table4 (length))
 
-        allocate (des0 (length))
-        allocate (des1 (length))
-        allocate (des2 (length))
-        allocate (des3 (length))
-        allocate (des4 (length))
+        if (.not. allocated (des0)) allocate (des0 (length))
+        if (.not. allocated (des1)) allocate (des1 (length))
+        if (.not. allocated (des2)) allocate (des2 (length))
+        if (.not. allocated (des3)) allocate (des3 (length))
+        if (.not. allocated (des4)) allocate (des4 (length))
 
         call qs_table0 (length)
         call qs_table1 (length)


### PR DESCRIPTION
**Description**

Brings update from internal development branch to GitHub main branch (to bring to dev/gfdl_am5).
Turns off saturation adjustment in the 2dz filter for non-SHiELD configuration.
This will change answers for runs using fv_sg_adj > 0 in AM5.

Fixes # (issue)

**How Has This Been Tested?**

Tested by CI and by Linjiong.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
