### PR TITLE
Fix uninitialized values in `cs_profile` when `iv == -3`

### DIFF
--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -2044,6 +2044,7 @@ else ! all others
        grat = delp(i,km-1) / delp(i,km)
        q(i,km) = ( 3.*(a4(1,i,k-1)+d4(i)*a4(1,i,k)) - grat*qs(i) - q(i,k-1) )/bet
        q(i,km+1) = qs(i)
+       gam(i,km) = d4(i) / bet
     enddo
 
   else ! all others


### PR DESCRIPTION
**Description**

Following the suggestion from @lharris4 in https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/301#issuecomment-1775426281, this assigns values to `gam(i,km)` consistent with the interior of the column when `iv == -3` in `cs_profile`.  It should be expected to change answers for non-hydrostatic simulations where `fv_core_nml.kord_wz < -7`. 

Fixes #301

**How Has This Been Tested?**

This has not been tested for scientific correctness, though I have tested that the change proposed here addresses the non-reproducibility issue identified in #301.  I now get bitwise-identical results every time I run the model in this configuration.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
