### PR TITLE
Redesign saturation table initialization

### DIFF
--- a/driver/GFDL/atmosphere.F90
+++ b/driver/GFDL/atmosphere.F90
@@ -95,7 +95,7 @@ use amip_interp_mod,      only: forecast_mode
 #endif
 
 use mpp_domains_mod, only:  mpp_get_data_domain, mpp_get_compute_domain
-use gfdl_mp_mod,        only: gfdl_mp_init, gfdl_mp_end
+use gfdl_mp_mod,        only: qs_init, gfdl_mp_init, gfdl_mp_end
 use coarse_graining_mod, only: coarse_graining_init
 use coarse_grained_diagnostics_mod, only: fv_coarse_diag_init, fv_coarse_diag
 use coarse_grained_restart_files_mod, only: fv_coarse_restart_init
@@ -314,6 +314,8 @@ contains
 
    if (Atm(mygrid)%flagstruct%do_inline_mp) then
      call gfdl_mp_init(input_nml_file, stdlog(), Atm(mygrid)%flagstruct%hydrostatic)
+   else
+     call qs_init
    endif
 
    call timing_on('FV_RESTART')

--- a/model/gfdl_mp.F90
+++ b/model/gfdl_mp.F90
@@ -7233,8 +7233,6 @@ function es_core (length, tk, table, des)
 
     real :: ap1, tmin
 
-    if (.not. tables_are_initialized) call qs_init
-
     tmin = tice - 160.
     ap1 = 10. * dim (tk, tmin) + 1.
     ap1 = min (2621., ap1)


### PR DESCRIPTION
**Description**

Bringing updates made by Linjiong Zhou to the main branch.  Will merge to the dev/gfdl_am5 branch.  

Call qs_init in the AM model when the GFDL MP isn't used.
Remove the redundant qs_init in the GFDL MP.

Fixes # (issue)

**How Has This Been Tested?**

Tested by FV3 Team developers.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
