### PR TITLE
Include surface ocean current in the computation of air-sea fluxes

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -2390,6 +2390,68 @@ contains
       endif
     endif
 
+    ! Deal with ssu and ssv
+    if (IPD_control%cplocn2atm .and. IPD_control%icplocn2atm==1) then
+      ! Extract the coupling field
+      do nb = 1,Atm_block%nblks
+        blen = Atm_block%blksz(nb)
+        do ix = 1, blen
+          i = Atm_block%index(nb)%ii(ix)
+          j = Atm_block%index(nb)%jj(ix)
+          Atm(mygrid)%parent2nest_2d(i,j) = IPD_Data(nb)%Sfcprop%ssu(ix)
+        enddo
+      enddo
+      ! Loop through and fill all nested grids
+      do n=2,ngrids
+        if (n==mygrid .or. mygrid==Atm(n)%parent_grid%grid_number) then
+          call fill_nested_grid_cpl(n, n==mygrid)
+        endif
+      enddo
+      ! Update the nested grids
+      if (Atm(mygrid)%neststruct%nested) then
+        do nb = 1,Atm_block%nblks
+          blen = Atm_block%blksz(nb)
+          do ix = 1, blen
+            i = Atm_block%index(nb)%ii(ix)
+            j = Atm_block%index(nb)%jj(ix)
+            if (IPD_data(nb)%Sfcprop%oceanfrac(ix) > 0.) then
+              IPD_data(nb)%Sfcprop%ssu(ix) = Atm(mygrid)%parent2nest_2d(i,j)
+            endif
+          enddo
+        enddo
+      endif
+
+      ! Extract the coupling field
+      do nb = 1,Atm_block%nblks
+        blen = Atm_block%blksz(nb)
+        do ix = 1, blen
+          i = Atm_block%index(nb)%ii(ix)
+          j = Atm_block%index(nb)%jj(ix)
+          Atm(mygrid)%parent2nest_2d(i,j) = IPD_Data(nb)%Sfcprop%ssv(ix)
+        enddo
+      enddo
+      ! Loop through and fill all nested grids
+      do n=2,ngrids
+        if (n==mygrid .or. mygrid==Atm(n)%parent_grid%grid_number) then
+          call fill_nested_grid_cpl(n, n==mygrid)
+        endif
+      enddo
+      ! Update the nested grids
+      if (Atm(mygrid)%neststruct%nested) then
+        do nb = 1,Atm_block%nblks
+          blen = Atm_block%blksz(nb)
+          do ix = 1, blen
+            i = Atm_block%index(nb)%ii(ix)
+            j = Atm_block%index(nb)%jj(ix)
+            if (IPD_data(nb)%Sfcprop%oceanfrac(ix) > 0.) then
+              IPD_data(nb)%Sfcprop%ssv(ix) = Atm(mygrid)%parent2nest_2d(i,j)
+            endif
+          enddo
+        enddo
+      endif
+
+    endif
+
     ! Deal with zorlwav (sea surface roughness length)
     if (IPD_control%cplwav2atm) then
       ! Extract the coupling field

--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -2416,6 +2416,8 @@ contains
             j = Atm_block%index(nb)%jj(ix)
             if (IPD_data(nb)%Sfcprop%oceanfrac(ix) > 0.) then
               IPD_data(nb)%Sfcprop%ssu(ix) = Atm(mygrid)%parent2nest_2d(i,j)
+            else
+              IPD_data(nb)%Sfcprop%ssu(ix) = 0.0_kind_phys
             endif
           enddo
         enddo
@@ -2445,6 +2447,8 @@ contains
             j = Atm_block%index(nb)%jj(ix)
             if (IPD_data(nb)%Sfcprop%oceanfrac(ix) > 0.) then
               IPD_data(nb)%Sfcprop%ssv(ix) = Atm(mygrid)%parent2nest_2d(i,j)
+            else
+              IPD_data(nb)%Sfcprop%ssv(ix) = 0.0_kind_phys
             endif
           enddo
         enddo

--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -2390,7 +2390,7 @@ contains
       endif
     endif
 
-    ! Deal with ssu and ssv
+    ! Deal with usfco and vsfco
     if (IPD_control%cplocn2atm .and. IPD_control%icplocn2atm==1) then
       ! Extract the coupling field
       do nb = 1,Atm_block%nblks
@@ -2398,7 +2398,7 @@ contains
         do ix = 1, blen
           i = Atm_block%index(nb)%ii(ix)
           j = Atm_block%index(nb)%jj(ix)
-          Atm(mygrid)%parent2nest_2d(i,j) = IPD_Data(nb)%Sfcprop%ssu(ix)
+          Atm(mygrid)%parent2nest_2d(i,j) = IPD_Data(nb)%Sfcprop%usfco(ix)
         enddo
       enddo
       ! Loop through and fill all nested grids
@@ -2415,9 +2415,9 @@ contains
             i = Atm_block%index(nb)%ii(ix)
             j = Atm_block%index(nb)%jj(ix)
             if (IPD_data(nb)%Sfcprop%oceanfrac(ix) > 0.) then
-              IPD_data(nb)%Sfcprop%ssu(ix) = Atm(mygrid)%parent2nest_2d(i,j)
+              IPD_data(nb)%Sfcprop%usfco(ix) = Atm(mygrid)%parent2nest_2d(i,j)
             else
-              IPD_data(nb)%Sfcprop%ssu(ix) = 0.0_kind_phys
+              IPD_data(nb)%Sfcprop%usfco(ix) = 0.0_kind_phys
             endif
           enddo
         enddo
@@ -2429,7 +2429,7 @@ contains
         do ix = 1, blen
           i = Atm_block%index(nb)%ii(ix)
           j = Atm_block%index(nb)%jj(ix)
-          Atm(mygrid)%parent2nest_2d(i,j) = IPD_Data(nb)%Sfcprop%ssv(ix)
+          Atm(mygrid)%parent2nest_2d(i,j) = IPD_Data(nb)%Sfcprop%vsfco(ix)
         enddo
       enddo
       ! Loop through and fill all nested grids
@@ -2446,9 +2446,9 @@ contains
             i = Atm_block%index(nb)%ii(ix)
             j = Atm_block%index(nb)%jj(ix)
             if (IPD_data(nb)%Sfcprop%oceanfrac(ix) > 0.) then
-              IPD_data(nb)%Sfcprop%ssv(ix) = Atm(mygrid)%parent2nest_2d(i,j)
+              IPD_data(nb)%Sfcprop%vsfco(ix) = Atm(mygrid)%parent2nest_2d(i,j)
             else
-              IPD_data(nb)%Sfcprop%ssv(ix) = 0.0_kind_phys
+              IPD_data(nb)%Sfcprop%vsfco(ix) = 0.0_kind_phys
             endif
           enddo
         enddo

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1269,8 +1269,8 @@ module fv_arrays_mod
     real, _ALLOCATABLE :: sgh(:,:)      _NULL  !< Terrain standard deviation
     real, _ALLOCATABLE :: oro(:,:)      _NULL  !< land fraction (1: all land; 0: all water)
     real, _ALLOCATABLE :: ts(:,:)       _NULL  !< skin temperature (sst) from NCEP/GFS (K) -- tile
-    real, _ALLOCATABLE :: ssu(:,:)      _NULL  !< sea surface current (zonal) from NCEP/GFS (m s-1) -- tile
-    real, _ALLOCATABLE :: ssv(:,:)      _NULL  !< sea surface current (meridional) from NCEP/GFS (m s-1) -- tile
+    real, _ALLOCATABLE :: usfco(:,:)    _NULL  !< sea surface current (zonal) from NCEP/GFS (m s-1) -- tile
+    real, _ALLOCATABLE :: vsfco(:,:)    _NULL  !< sea surface current (meridional) from NCEP/GFS (m s-1) -- tile
 
 ! For stochastic kinetic energy backscatter (SKEB)
     real, _ALLOCATABLE :: diss_est(:,:,:) _NULL !< dissipation estimate taken from 'heat_source'

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1269,6 +1269,8 @@ module fv_arrays_mod
     real, _ALLOCATABLE :: sgh(:,:)      _NULL  !< Terrain standard deviation
     real, _ALLOCATABLE :: oro(:,:)      _NULL  !< land fraction (1: all land; 0: all water)
     real, _ALLOCATABLE :: ts(:,:)       _NULL  !< skin temperature (sst) from NCEP/GFS (K) -- tile
+    real, _ALLOCATABLE :: ssu(:,:)      _NULL  !< sea surface current (zonal) from NCEP/GFS (m s-1) -- tile
+    real, _ALLOCATABLE :: ssv(:,:)      _NULL  !< sea surface current (meridional) from NCEP/GFS (m s-1) -- tile
 
 ! For stochastic kinetic energy backscatter (SKEB)
     real, _ALLOCATABLE :: diss_est(:,:,:) _NULL !< dissipation estimate taken from 'heat_source'

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1269,8 +1269,6 @@ module fv_arrays_mod
     real, _ALLOCATABLE :: sgh(:,:)      _NULL  !< Terrain standard deviation
     real, _ALLOCATABLE :: oro(:,:)      _NULL  !< land fraction (1: all land; 0: all water)
     real, _ALLOCATABLE :: ts(:,:)       _NULL  !< skin temperature (sst) from NCEP/GFS (K) -- tile
-    real, _ALLOCATABLE :: usfco(:,:)    _NULL  !< sea surface current (zonal) from NCEP/GFS (m s-1) -- tile
-    real, _ALLOCATABLE :: vsfco(:,:)    _NULL  !< sea surface current (meridional) from NCEP/GFS (m s-1) -- tile
 
 ! For stochastic kinetic energy backscatter (SKEB)
     real, _ALLOCATABLE :: diss_est(:,:,:) _NULL !< dissipation estimate taken from 'heat_source'


### PR DESCRIPTION
**Description**

Update surface layer scheme to include surface ocean current in the computation of air sea fluxes.
Transfer surface ocean current field to nested grids.

Fixes #312 

**How Has This Been Tested?**

The updated code has been tested successfully in the HAFS-MOM6 application.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

Co-authored-by @binli2337 ,@BinLiu-NOAA, @weiguoWang-NOAA, @BijuThomas-NOAA, @hyunsookkim-NOAA, @XuLi-NOAA, @MariaAristizabal-NOAA, @JohnSteffen-NOAA