### PR TITLE
Port `delp_dycore` diagnostic to public version of SHiELD

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -960,8 +960,10 @@ contains
           !            'Relative Humidity', '%', missing_value=missing_value, range=rhrange )
           id_delp = register_diag_field ( trim(field), 'delp', axes(1:3), Time,        &
                'pressure thickness'//massdef_str, 'pa', missing_value=missing_value )
-          id_delp_dycore = register_diag_field ( trim(field), 'delp_dycore', axes(1:3), Time,        &
-               'pressure thickness as seen by the dynamical core', 'pa', missing_value=missing_value )
+#ifdef GFS_PHYS
+          id_delp_total = register_diag_field ( trim(field), 'delp_total', axes(1:3), Time,        &
+               'FV3 pressure thickness (dry air + all water species)', 'pa', missing_value=missing_value )
+#endif
           if ( .not. Atm(n)%flagstruct%hydrostatic )                                        &
                id_delz = register_diag_field ( trim(field), 'delz', axes(1:3), Time,        &
                'height thickness', 'm', missing_value=missing_value )
@@ -3014,8 +3016,6 @@ contains
           endif
        endif
 
-       if(id_delp_dycore > 0) used=send_data(id_delp_dycore, Atm(n)%delp(isc:iec,jsc:jec,:), Time)
-
 #ifdef GFS_PHYS
        if(id_delp > 0 .or. id_cape > 0 .or. id_cin > 0 .or. &
             ((.not. Atm(n)%flagstruct%hydrostatic) .and. (id_pfnh > 0 .or. id_ppnh > 0)) .or. &
@@ -3029,6 +3029,7 @@ contains
           enddo
           if (id_delp > 0) used=send_data(id_delp, wk, Time)
        endif
+       if(id_delp_total > 0) used=send_data(id_delp_total, Atm(n)%delp(isc:iec,jsc:jec,:), Time)
 #else
        if(id_delp > 0) used=send_data(id_delp, Atm(n)%delp(isc:iec,jsc:jec,:), Time)
 #endif

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -960,6 +960,8 @@ contains
           !            'Relative Humidity', '%', missing_value=missing_value, range=rhrange )
           id_delp = register_diag_field ( trim(field), 'delp', axes(1:3), Time,        &
                'pressure thickness'//massdef_str, 'pa', missing_value=missing_value )
+          id_delp_dycore = register_diag_field ( trim(field), 'delp_dycore', axes(1:3), Time,        &
+               'pressure thickness as seen by the dynamical core', 'pa', missing_value=missing_value )
           if ( .not. Atm(n)%flagstruct%hydrostatic )                                        &
                id_delz = register_diag_field ( trim(field), 'delz', axes(1:3), Time,        &
                'height thickness', 'm', missing_value=missing_value )
@@ -3012,6 +3014,7 @@ contains
           endif
        endif
 
+       if(id_delp_dycore > 0) used=send_data(id_delp_dycore, Atm(n)%delp(isc:iec,jsc:jec,:), Time)
 
 #ifdef GFS_PHYS
        if(id_delp > 0 .or. id_cape > 0 .or. id_cin > 0 .or. &

--- a/tools/fv_diagnostics.h
+++ b/tools/fv_diagnostics.h
@@ -105,5 +105,7 @@
      integer :: id_uw, id_vw
      integer :: id_lagrangian_tendency_of_hydrostatic_pressure
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge, id_u_dt_nudge, id_v_dt_nudge
-     integer :: id_delp_dycore
+#ifdef GFS_PHYS
+     integer :: id_delp_total
+#endif
 #endif _FV_DIAG__

--- a/tools/fv_diagnostics.h
+++ b/tools/fv_diagnostics.h
@@ -105,4 +105,5 @@
      integer :: id_uw, id_vw
      integer :: id_lagrangian_tendency_of_hydrostatic_pressure
      integer :: id_t_dt_nudge, id_ps_dt_nudge, id_delp_dt_nudge, id_u_dt_nudge, id_v_dt_nudge
+     integer :: id_delp_dycore
 #endif _FV_DIAG__


### PR DESCRIPTION
**Description**

This PR adds a diagnostic for the pressure thickness which includes the mass of water condensates (`delp_dycore`).  This is the actual pressure thickness used internally by the dynamical core to define things like tracer mixing ratios, and so it is useful to be able to output it for diagnosing budgets.  In many ways it is a simpler diagnostic to implement than the existing `delp` diagnostic.

xref: I implemented this diagnostic as part of another merge request to the internal version of SHiELD (see [this commit](https://gitlab.gfdl.noaa.gov/fv3team/atmos_cubed_sphere/-/merge_requests/134/diffs?commit_id=803a79cc4e8b8b0e5c175790af88282fff32d008); note authentication is needed to access the link).  

Since this is such a simple change, and one that already exists in the internal version of SHiELD, I hope we can review / merge it quickly, as I need it for a new simulation.  Thanks!

cc: @lharris4 and @bensonr

**How Has This Been Tested?**

I tested this in a short C12 resolution simulation within a Docker container, and validated that I could reproduce the existing `delp` diagnostic using this new `delp_dycore` diagnostic and the sum of the condensate tracers ([notebook](https://gist.github.com/spencerkclark/aa83bdecf4e6a5dce31692b826d3a104)).

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
