### PR TITLE
HAILCAST bug fix (units issue)

### DIFF
--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -1092,8 +1092,7 @@ CONTAINS
       IF (D.GT.0.254) D = 0.  !just consider missing for now if > 10 in
 
       !assign hail size in mm for output
-      !dhails(i) = D * 1000
-      dhails(i) = D
+      dhails(i) = D * 1000
 
     ENDDO  !end embryo size loop
 


### PR DESCRIPTION
**Description**

This corrects a units issue in the HAILCAST diagnostic code.  Prior to this fix, the diagnosed hail diameter was labeled in millimeters, but the calculated values (in the output) were actually in meters.  This created the perception of very small hail, often just a fraction of a millimeter.  The corrected code yields hail diameter in millimeters.  Thanks to @adams-selin (HAILCAST developer) for the troubleshooting assistance and the bug fix.

**How Has This Been Tested?**

This modification has been tested on Hera in a 36-h RRFS retrospective case (CONUS domain).  As expected, the diagnosed hail diameters are simply increased by a factor of 1000.  As an example, a screenshot is attached of the "hailcast_dhail" array:  previous values are shown at left, with updated (corrected) values on the right.

<img width="1148" alt="hail" src="https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/assets/14337181/0d35e434-621b-4563-978e-90c1d8647e8f">


**Checklist:**

Please check all whether they apply or not
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published in downstream modules
