### PR TITLE
Add windspeed at 100m diagnostic

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -1202,6 +1202,8 @@ contains
                         '100-m AGL u-wind', 'm/s', missing_value=missing_value )
        id_v100m = register_diag_field ( trim(field), 'v100m', axes(1:2), Time,       &
                         '100-m AGL v-wind', 'm/s', missing_value=missing_value )
+       id_wind100m = register_diag_field ( trim(field), 'wind100m', axes(1:2), Time,       &
+                        '100-m AGL windspeed', 'm/s', missing_value=missing_value )
 !--------------------------
 ! relative humidity (physics definition):
 !--------------------------
@@ -3089,7 +3091,7 @@ contains
             used=send_data(id_pmaskv2, a2, Time)
        endif
 
-       if ( id_u100m>0 .or. id_v100m>0 .or.  id_w100m>0 .or. id_w5km>0 .or. id_w2500m>0 &
+       if ( id_u100m>0 .or. id_v100m>0 .or. id_wind100m>0 .or.  id_w100m>0 .or. id_w5km>0 .or. id_w2500m>0 &
             & .or. id_w1km>0 .or. id_basedbz>0 .or. id_dbz4km>0) then
           if (.not.allocated(wz)) allocate ( wz(isc:iec,jsc:jec,npz+1) )
           if ( Atm(n)%flagstruct%hydrostatic) then
@@ -3150,15 +3152,29 @@ contains
             used=send_data(id_w100m, a2, Time)
             if(prt_minmax) call prt_maxmin('w100m', a2, isc, iec, jsc, jec, 0, 1, 1.)
        endif
-       if ( id_u100m>0 ) then
-            call interpolate_z(isc, iec, jsc, jec, npz, 100., wz, Atm(n)%ua(isc:iec,jsc:jec,:), a2)
-            used=send_data(id_u100m, a2, Time)
-            if(prt_minmax) call prt_maxmin('u100m', a2, isc, iec, jsc, jec, 0, 1, 1.)
+
+       if ( id_u100m>0 .or. id_wind100m>0 ) then
+            call interpolate_z(isc, iec, jsc, jec, npz, 100., wz, Atm(n)%ua(isc:iec,jsc:jec,:), u2)
+            if (id_u100m>0) then
+               used=send_data(id_u100m, u2, Time)
+               if(prt_minmax) call prt_mxm('u100m', u2, isc, iec, jsc, jec, 0, 1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
+            endif
        endif
-       if ( id_v100m>0 ) then
-            call interpolate_z(isc, iec, jsc, jec, npz, 100., wz, Atm(n)%va(isc:iec,jsc:jec,:), a2)
-            used=send_data(id_v100m, a2, Time)
-            if(prt_minmax) call prt_maxmin('v100m', a2, isc, iec, jsc, jec, 0, 1, 1.)
+       if ( id_v100m>0 .or. id_wind100m>0 ) then
+            call interpolate_z(isc, iec, jsc, jec, npz, 100., wz, Atm(n)%va(isc:iec,jsc:jec,:), v2)
+            if (id_v100m > 0) then
+               used=send_data(id_v100m, v2, Time)
+               if(prt_minmax) call prt_mxm('v100m', v2, isc, iec, jsc, jec, 0, 1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
+            endif
+       endif
+       if ( id_wind100m > 0) then
+          do j=jsc,jec
+             do i=isc,iec
+                a2(i,j) = sqrt(u2(i,j)**2 + v2(i,j)**2)
+             enddo
+          enddo
+          used=send_data(id_wind100m, a2, Time)
+          if(prt_minmax) call prt_mxm('wind100m', a2, isc, iec, jsc, jec, 0, 1, 1., Atm(n)%gridstruct%area_64, Atm(n)%domain)
        endif
 
        if ( rainwat > 0 .and. (id_dbz>0 .or. id_maxdbz>0 .or. id_basedbz>0 .or. id_dbz4km>0 &

--- a/tools/fv_diagnostics.h
+++ b/tools/fv_diagnostics.h
@@ -60,7 +60,7 @@
             id_rh300_cmip,  id_rh250_cmip, id_rh100_cmip, id_rh50_cmip,  id_rh10_cmip
 
  integer :: id_hght3d, id_any_hght
- integer :: id_u100m, id_v100m, id_w100m
+ integer :: id_u100m, id_v100m, id_w100m, id_wind100m
 
      ! For initial conditions:
      integer ic_ps, ic_ua, ic_va, ic_ppt


### PR DESCRIPTION
Adds ability to output windspeed at 100m rather than calculate this from u100m and v100m.

**Description**

Calculating windspeed from 6 hour averages of u100m and v100m underestimates the windspeed. This has
consequences for fields where wind energy is of interest.

**How Has This Been Tested?**

Ran a 1 day run with instantaneous windspeed and u100m, v100m output as well as 6 hr average output. 
instantaneous output matched within 10-6 m/s, the 6 hour averaged windspeed was underestimated if using u100m and v100m fields.
