### PR TITLE
Address compiler warnings for FV3 raised in an issue

### DIFF
--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -4,7 +4,7 @@ set(R8_flags "-real-size 64") # Fortran flags for 64BIT precision
 set(R8_flags "${R8_flags} -no-prec-div -no-prec-sqrt")
 
 # Intel Fortran
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -fpp -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte -qno-opt-dynamic-align ${${kind}_flags}")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -fpp -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -sox -align array64byte -qno-opt-dynamic-align ${${kind}_flags}")
 
 set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverride-limits")
 

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -378,7 +378,7 @@ contains
 
         reg_bc_update_time=current_time_in_seconds
         call set_regional_BCs          & !<-- Insert values into the boundary region valid for the start of this large timestep.
-              (delp,delz,w,pt                                     &
+              (delp,w,pt                                          &
 #ifdef USE_COND
                ,q_con                                             &
 #endif

--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -2273,6 +2273,10 @@ module fv_nwp_nudge_mod
       real :: kappax(is:ie,js:je,npz)
 #endif
 
+#if defined (BYPASS_BREED_SLP_INLINE)
+    peln = 0.0 ! to silence compiler warning. A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.
+    call mpp_error(fatal, "breed_slp_inline routine has been disabled")
+#else
       if ( forecast_mode ) return
 
       agrid => gridstruct%agrid_64
@@ -2715,6 +2719,7 @@ module fv_nwp_nudge_mod
 
     nullify(agrid)
     nullify(area)
+#endif
 
   end subroutine breed_slp_inline
 

--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -84,6 +84,11 @@ CONTAINS
         !write(unit, nml=fv_diagnostics_nml)
         !!end hailcast nml
 
+
+        ! need to set a default value for istatus because of it's intent(out) status
+        ! this value is not checked on return
+        istatus = 0
+
         if (mpp_pe() == mpp_root_pe()) then
             print*, 'do_hailcast = ', do_hailcast
         end if

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -5683,7 +5683,7 @@ end subroutine terminator_tracers
 
  call mpp_error(FATAL, 'SuperCell sounding cannot perform with GFS Physics.')
  tp=0.
- qb=0.
+ qp=0.
 
 #else
 

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -3192,7 +3192,7 @@
 ! Iterate then interpolate to get balanced pt & pk on the sphere
 ! Adjusting ptop
         call SuperK_u(npz, zs1, uz1, dudz)
-        call balanced_K(npz, is, ie, js, je, ng, pe1(npz+1), ze1, ts1, qs1, uz1, dudz, pe, pk, pt,  &
+        call balanced_K(npz, is, ie, js, je, ng, pe1(npz+1), ze1, ts1, qs1, uz1, dudz, pe, pt,  &
                         delz, zvir, ptop, ak, bk, agrid)
         do j=js,je
            do i=is,ie
@@ -5464,7 +5464,7 @@ end subroutine terminator_tracers
 
  end subroutine SuperK_Sounding
 
- subroutine balanced_K(km, is, ie, js, je, ng, ps0, ze1, ts1, qs1, uz1, dudz, pe, pk, pt,  &
+ subroutine balanced_K(km, is, ie, js, je, ng, ps0, ze1, ts1, qs1, uz1, dudz, pe, pt,  &
                        delz, zvir, ptop, ak, bk, agrid)
  integer, intent(in):: is, ie, js, je, ng, km
  real, intent(in), dimension(km  ):: ts1, qs1, uz1, dudz
@@ -5475,7 +5475,6 @@ end subroutine terminator_tracers
  real, intent(inout), dimension(km+1):: ak, bk
  real, intent(inout), dimension(is:ie,js:je,km):: pt
  real, intent(inout), dimension(is:,js:,1:) :: delz
- real, intent(out), dimension(is:ie,js:je,km+1):: pk
 ! pt is FV's cp*thelta_v
  real, intent(inout), dimension(is-1:ie+1,km+1,js-1:je+1):: pe
 ! Local
@@ -5683,6 +5682,8 @@ end subroutine terminator_tracers
 #ifdef GFS_PHYS
 
  call mpp_error(FATAL, 'SuperCell sounding cannot perform with GFS Physics.')
+ tp=0.
+ qb=0.
 
 #else
 


### PR DESCRIPTION
Fixes the compiler warnings in fv_regional_bc.F90, test_cases.F90, and module_diag_hailcast.F90 as identified by NCO.  Unfortunately the logic in fv_nudge.F90 is too complex to easily address the goto identified herein.

Fixes #307 

**How Has This Been Tested?**

No tests have yet been run.  I will ask the relevant EPIC team members to test when ready.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
