### PR TITLE
Fix microphysics rate accumulation bug when `ntimes` > 1

### DIFF
--- a/model/gfdl_mp.F90
+++ b/model/gfdl_mp.F90
@@ -1229,7 +1229,7 @@ subroutine mpdrv (hydrostatic, ua, va, wa, delp, pt, qv, ql, qr, qi, qs, qg, &
     ! unit convert to mm/day
     ! -----------------------------------------------------------------------
 
-    convt = 86400. * rgrav / dts
+    convt = 86400. * rgrav / dtm
 
     do i = is, ie
 
@@ -1395,7 +1395,7 @@ subroutine mpdrv (hydrostatic, ua, va, wa, delp, pt, qv, ql, qr, qi, qs, qg, &
         if (fix_negative) &
             call neg_adj (ks, ke, tz, dp, qvz, qlz, qrz, qiz, qsz, qgz, cond)
 
-        condensation (i) = condensation (i) + cond * convt * ntimes
+        condensation (i) = condensation (i) + cond * convt
 
         ! -----------------------------------------------------------------------
         ! fast microphysics loop


### PR DESCRIPTION
**Description**

This PR addresses an issue encountered when running SHiELD in a configuration such that the inline microphysics was called multiple times per vertical remapping.  This is any case where `gfdl_mp_nml.mp_time` divides `coupler_nml.dt_atmos / fv_core_nml.k_split` at least twice.  In such circumstances the large-scale precipitation rates passed to the rest of the physics (namely the land surface model) were incorrectly inflated by a factor of the number of microphysics substeps per vertical remapping.  

A simple fix is to divide by the length of remapping timestep instead of the microphysics timestep when converting precipitation (or any other process) increments to rates.  This ensures that the process rates are properly averaged across microphysics substeps while being accumulated for eventual averaging across vertical remapping steps.

**How Has This Been Tested?**

This was tested by running a 10-day simulation with and without this bug fix in a configuration with a remapping timestep of 450 seconds, and a microphysics timestep of 150 seconds.  We output instantaneous diagnostics of the total water path, and interval-average diagnostics of the precipitation rate and latent heat flux every 6 hours.  These diagnostics were used to compute the global water budget:

$$\left< \frac{\partial TWP}{\partial t} \right> = \left< E - P \right>$$

Here the angle brackets represent global means, $TWP$ is the total water path, $E$ is the evaporation rate, and $P$ is the precipitation rate.  This relationship should hold exactly in the model based on conservation of water.  In the simulation without the bug fix, the relationship clearly does not hold, due to a triple-counted large-scale precipitation rate; note the large residual, representing the difference between left and right sides of the equation.  In the simulation with the bug fix, the relationship holds to within rounding error.

![2024-03-04-water-budget-comparison-shield-bug-fix](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/assets/6628425/e00b1cdb-34f5-41e7-887c-7ac31226240c)

This issue and fix were discussed offline with @linjiongzhou and @lharris4.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
