### PR TITLE
nesting bug fixes for uninitialized variable in fv3 and incorrect tile number in fv3atm

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -864,17 +864,18 @@ contains
  end subroutine atmosphere_pref
 
 
- subroutine atmosphere_control_data (i1, i2, j1, j2, kt, p_hydro, hydro, tile_num)
+ subroutine atmosphere_control_data (i1, i2, j1, j2, kt, p_hydro, hydro, tile_of_mosaic, global_tile_num)
    integer, intent(out)           :: i1, i2, j1, j2, kt
    logical, intent(out), optional :: p_hydro, hydro
-   integer, intent(out), optional :: tile_num
+   integer, intent(out), optional :: tile_of_mosaic, global_tile_num
    i1 = Atm(mygrid)%bd%isc
    i2 = Atm(mygrid)%bd%iec
    j1 = Atm(mygrid)%bd%jsc
    j2 = Atm(mygrid)%bd%jec
    kt = Atm(mygrid)%npz
 
-   if (present(tile_num)) tile_num = Atm(mygrid)%tile_of_mosaic
+   if (present(global_tile_num)) global_tile_num = Atm(mygrid)%global_tile
+   if (present(tile_of_mosaic)) tile_of_mosaic = Atm(mygrid)%tile_of_mosaic
    if (present(p_hydro)) p_hydro   = Atm(mygrid)%flagstruct%phys_hydrostatic
    if (present(  hydro))   hydro   = Atm(mygrid)%flagstruct%hydrostatic
 

--- a/model/fv_nesting.F90
+++ b/model/fv_nesting.F90
@@ -1528,6 +1528,7 @@ end subroutine dealloc_nested_buffers
    rainwat = get_tracer_index (MODEL_ATMOS, 'rainwat')
    snowwat = get_tracer_index (MODEL_ATMOS, 'snowwat')
    graupel = get_tracer_index (MODEL_ATMOS, 'graupel')
+   hailwat = get_tracer_index (MODEL_ATMOS, 'hailwat')
 
    if (is == 1) then
       if (.not. allocated(dum_West)) then


### PR DESCRIPTION
**Description**

This fixes #328 by initializing the hailwat variable to the hailwat tracer index.
It fixes #329 by allowing the caller to request either the global_tile or tile_in_mosaic.

- fixes #328
- fixes #329

**How Has This Been Tested?**

1. Running the test case that failed. It's a rotated cube sphere with a large static nest, using GFS physics
2. Running regression tests on Hera CentOS

The Hera Rocky tests await bug fixes to the regression tests which should be available this week.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
