### PR TITLE
Remove -DUSE_COND and -DMOIST_CAPPA for hydrostatic runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(GFS_TYPES   "Enable compiler definition -DGFS_TYPES"                OFF)
 option(use_WRTCOMP "Enable compiler definition -Duse_WRTCOMP"              OFF)
 option(INTERNAL_FILE_NML     "Enable compiler definition -DINTERNAL_FILE_NML"      ON)
 option(ENABLE_QUAD_PRECISION "Enable compiler definition -DENABLE_QUAD_PRECISION"  ON)
+option(HYDRO       "Enable compiler definition -DHYDRO"                    OFF)
 
 find_package(MPI REQUIRED)
 if(OPENMP)
@@ -115,11 +116,13 @@ list(APPEND driver_srcs
 list(APPEND fv3_srcs ${model_srcs}
                      ${tools_srcs})
 
-list(APPEND fv3_defs SPMD
-                     MOIST_CAPPA
-                     USE_COND)
+list(APPEND fv3_defs SPMD)
 
 # Additional (optional) compiler definitions
+if (NOT HYDRO)
+  list(APPEND fv3_defs USE_COND MOIST_CAPPA)
+endif()
+
 if(DEBUG)
   list(APPEND fv3_defs DEBUG)
 endif()


### PR DESCRIPTION
**Description**

The compiling flags -DUSE_COND and -DMOIST_CAPPA are removed for hydrostatic runs.

Fixes # (issue)

**How Has This Been Tested?**

It was tested on Hera with intel and gnu. A regression test with hydrostatic options is added in UFS.
Related PRs:

https://github.com/NOAA-EMC/fv3atm/pull/828
https://github.com/ufs-community/ufs-weather-model/pull/2255

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
