### PR TITLE
Set cdata%thrd_cnt in driver/fvGFS/atmosphere.F90

### DIFF
--- a/driver/fvGFS/atmosphere.F90
+++ b/driver/fvGFS/atmosphere.F90
@@ -493,6 +493,7 @@ contains
    ! and thread number are not used; set to safe values
    cdata%blk_no = 1
    cdata%thrd_no = 1
+   cdata%thrd_cnt = 1
 
    ! Create shared data type for fast and slow physics, one for each thread
 #ifdef OPENMP


### PR DESCRIPTION
**Description**

All in the title. Required for supporting optional arguments in CCPP (see https://github.com/ufs-community/ufs-weather-model/pull/2205 and PRs listed there).

Working towards https://github.com/NCAR/ccpp-framework/issues/540

This is part of a large set of PRs:

https://github.com/NCAR/ccpp-framework/pull/552 
https://github.com/NOAA-EMC/fv3atm/pull/807 
[https://github.com/ufs-community/ufs-weather-model/pull/2205](https://github.com/ufs-community/ufs-weather-model/pull/2205/files)
https://github.com/ufs-community/ccpp-physics/pull/189 
https://github.com/NCAR/ccpp-framework/pull/556 (can be scheduled and merged anytime beforehand)
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/338 
https://github.com/NOAA-PSL/stochastic_physics/pull/79

**How Has This Been Tested?**

ufs-weather-model full regression testing on Hera (all tests b4b)

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
