### PR TITLE
Perturbation/Increments for cold starts

### DIFF
--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -365,19 +365,6 @@ contains
              else
                 if( is_master() ) write(*,*) 'Warm starting, calling fv_io_restart'
                 call fv_io_read_restart(Atm(n)%domain_for_read,Atm(n:n))
-                !====== PJP added DA functionality ======
-                if (Atm(n)%flagstruct%read_increment) then
-                   ! print point in middle of domain for a sanity check
-                   i = (Atm(n)%bd%isc + Atm(n)%bd%iec)/2
-                   j = (Atm(n)%bd%jsc + Atm(n)%bd%jec)/2
-                   k = Atm(n)%npz/2
-                   if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
-                   call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
-                        Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
-                        isc, jsc, iec, jec )
-                   if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
-                endif
-                !====== end PJP added DA functionailty======
              endif
 
              seconds = 0; days = 0   ! Restart needs to be modified to record seconds and days.
@@ -478,7 +465,19 @@ contains
 
           endif !external_ic vs. restart vs. idealized
 
-
+          !====== PJP added DA functionality ======
+           if (Atm(n)%flagstruct%read_increment) then
+              ! print point in middle of domain for a sanity check
+              i = (Atm(n)%bd%isc + Atm(n)%bd%iec)/2
+              j = (Atm(n)%bd%jsc + Atm(n)%bd%jec)/2
+              k = Atm(n)%npz/2
+              if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
+              call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
+                   Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
+                   isc, jsc, iec, jec )
+              if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
+           endif
+           !====== end PJP added DA functionailty======
        endif !n==this_grid
 
 


### PR DESCRIPTION
**Description**

Currently the model can only read in an increment file if initializing with a restart file.  This functionality is also used to read in ensemble perturbations, and should also work for a external initial condition. The solution is to move the call to read_da_inc outside the if external_ic/restart logic.


Fixes # (issue)

FV3 is not able to apply DA increment when cold staring #339


**How Has This Been Tested?**

So far, I have run limited regression tests on gaea, and tested that the perturbations are being read in during a cold start.  The regression tests pass.

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [ X I have performed a self-review of my own code
- [ X I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
