### PR TITLE
Feature/cubed sphere inc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,8 @@ list(APPEND tools_srcs
   tools/module_diag_hailcast.F90
   tools/sim_nc_mod.F90
   tools/sorted_index.F90
-  tools/test_cases.F90)
+  tools/test_cases.F90
+  tools/module_get_cubed_sphere_inc.F90)
 
 list(APPEND tools_srcs_extra
   tools/fv_iau_mod.F90)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ list(APPEND tools_srcs
   tools/sim_nc_mod.F90
   tools/sorted_index.F90
   tools/test_cases.F90
-  tools/module_cubed_sphere_inc.F90)
+  tools/cubed_sphere_inc_mod.F90)
 
 list(APPEND tools_srcs_extra
   tools/fv_iau_mod.F90)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ list(APPEND tools_srcs
   tools/sim_nc_mod.F90
   tools/sorted_index.F90
   tools/test_cases.F90
-  tools/module_get_cubed_sphere_inc.F90)
+  tools/module_cubed_sphere_inc.F90)
 
 list(APPEND tools_srcs_extra
   tools/fv_iau_mod.F90)

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -831,7 +831,7 @@ module fv_arrays_mod
                                        !< condition file (if nggps_ic or ecwmf_ic are .true.). This overrides the
                                        !< hard-coded levels in fv_eta. The default is .false.
    logical :: read_increment = .false.   !< read in analysis increment and add to restart
-   logical :: gaussian_increment = .true. !< increment is on Gaussian grid
+   logical :: increment_file_on_native_grid = .false. !< increment is on native cubed sphere grid grid else on Gaussian grid
 ! following are namelist parameters for Stochastic Energy Baskscatter dissipation estimate
    logical :: do_skeb  = .false.         !< save dissipation estimate
    integer :: skeb_npass  = 11           !< Filter dissipation estimate "skeb_npass" times

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -831,6 +831,7 @@ module fv_arrays_mod
                                        !< condition file (if nggps_ic or ecwmf_ic are .true.). This overrides the
                                        !< hard-coded levels in fv_eta. The default is .false.
    logical :: read_increment = .false.   !< read in analysis increment and add to restart
+   logical :: gaussian_increment = .true. !< increment is on Gaussian grid
 ! following are namelist parameters for Stochastic Energy Baskscatter dissipation estimate
    logical :: do_skeb  = .false.         !< save dissipation estimate
    integer :: skeb_npass  = 11           !< Filter dissipation estimate "skeb_npass" times

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -373,7 +373,7 @@ module fv_control_mod
      logical , pointer :: external_ic
      logical , pointer :: external_eta
      logical , pointer :: read_increment
-     logical , pointer :: gaussian_increment
+     logical , pointer :: increment_file_on_native_grid
      logical , pointer :: hydrostatic
      logical , pointer :: phys_hydrostatic
      logical , pointer :: use_hydro_pressure
@@ -950,8 +950,7 @@ module fv_control_mod
        external_ic                   => Atm%flagstruct%external_ic
        external_eta                  => Atm%flagstruct%external_eta
        read_increment                => Atm%flagstruct%read_increment
-       gaussian_increment            => Atm%flagstruct%gaussian_increment
-
+       increment_file_on_native_grid => Atm%flagstruct%increment_file_on_native_grid
        hydrostatic                   => Atm%flagstruct%hydrostatic
        phys_hydrostatic              => Atm%flagstruct%phys_hydrostatic
        use_hydro_pressure            => Atm%flagstruct%use_hydro_pressure
@@ -1093,7 +1092,7 @@ module fv_control_mod
             write_coarse_restart_files,&
             write_coarse_diagnostics,&
             write_only_coarse_intermediate_restarts, &
-            write_coarse_agrid_vel_rst, write_coarse_dgrid_vel_rst, ignore_rst_cksum, gaussian_increment
+            write_coarse_agrid_vel_rst, write_coarse_dgrid_vel_rst, ignore_rst_cksum, increment_file_on_native_grid
 
 
        ! Read FVCORE namelist

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -1072,7 +1072,7 @@ module fv_control_mod
             do_schmidt, do_cube_transform, &
             hord_mt, hord_vt, hord_tm, hord_dp, hord_tr, shift_fac, stretch_fac, target_lat, target_lon, &
             kord_mt, kord_wz, kord_tm, kord_tr, fv_debug, fv_timers, fv_land, nudge, do_sat_adj, do_inline_mp, do_f3d, &
-            external_ic, read_increment, gaussian_increment, ncep_ic, nggps_ic, hrrrv3_ic, ecmwf_ic, use_new_ncep, use_ncep_phy, fv_diag_ic, &
+            external_ic, read_increment, ncep_ic, nggps_ic, hrrrv3_ic, ecmwf_ic, use_new_ncep, use_ncep_phy, fv_diag_ic, &
             external_eta, res_latlon_dynamics, res_latlon_tracers, scale_z, w_max, z_min, lim_fac, &
             dddmp, d2_bg, d4_bg, vtdm4, trdm2, d_ext, delt_max, beta, non_ortho, n_sponge, &
             warm_start, adjust_dry_mass, mountain, d_con, ke_bg, nord, nord_tr, convert_ke, use_old_omega, &
@@ -1093,7 +1093,7 @@ module fv_control_mod
             write_coarse_restart_files,&
             write_coarse_diagnostics,&
             write_only_coarse_intermediate_restarts, &
-            write_coarse_agrid_vel_rst, write_coarse_dgrid_vel_rst, ignore_rst_cksum
+            write_coarse_agrid_vel_rst, write_coarse_dgrid_vel_rst, ignore_rst_cksum, gaussian_increment
 
 
        ! Read FVCORE namelist

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -373,6 +373,7 @@ module fv_control_mod
      logical , pointer :: external_ic
      logical , pointer :: external_eta
      logical , pointer :: read_increment
+     logical , pointer :: gaussian_increment
      logical , pointer :: hydrostatic
      logical , pointer :: phys_hydrostatic
      logical , pointer :: use_hydro_pressure
@@ -949,6 +950,7 @@ module fv_control_mod
        external_ic                   => Atm%flagstruct%external_ic
        external_eta                  => Atm%flagstruct%external_eta
        read_increment                => Atm%flagstruct%read_increment
+       gaussian_increment            => Atm%flagstruct%gaussian_increment
 
        hydrostatic                   => Atm%flagstruct%hydrostatic
        phys_hydrostatic              => Atm%flagstruct%phys_hydrostatic
@@ -1070,7 +1072,7 @@ module fv_control_mod
             do_schmidt, do_cube_transform, &
             hord_mt, hord_vt, hord_tm, hord_dp, hord_tr, shift_fac, stretch_fac, target_lat, target_lon, &
             kord_mt, kord_wz, kord_tm, kord_tr, fv_debug, fv_timers, fv_land, nudge, do_sat_adj, do_inline_mp, do_f3d, &
-            external_ic, read_increment, ncep_ic, nggps_ic, hrrrv3_ic, ecmwf_ic, use_new_ncep, use_ncep_phy, fv_diag_ic, &
+            external_ic, read_increment, gaussian_increment, ncep_ic, nggps_ic, hrrrv3_ic, ecmwf_ic, use_new_ncep, use_ncep_phy, fv_diag_ic, &
             external_eta, res_latlon_dynamics, res_latlon_tracers, scale_z, w_max, z_min, lim_fac, &
             dddmp, d2_bg, d4_bg, vtdm4, trdm2, d_ext, delt_max, beta, non_ortho, n_sponge, &
             warm_start, adjust_dry_mass, mountain, d_con, ke_bg, nord, nord_tr, convert_ke, use_old_omega, &

--- a/tools/cubed_sphere_inc_mod.F90
+++ b/tools/cubed_sphere_inc_mod.F90
@@ -45,7 +45,7 @@ module cubed_sphere_inc_mod
       ! Read increments
       call get_var5_r4( ncid, 'u_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%ua_inc )
       call get_var5_r4( ncid, 'v_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%va_inc )
-      call get_var5_r4( ncid, 'temp_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%temp_inc )
+      call get_var5_r4( ncid, 'T_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%temp_inc )
       call get_var5_r4( ncid, 'delp_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%delp_inc )
       if ( .not. Atm%flagstruct%hydrostatic ) then
          call get_var5_r4( ncid, 'delz_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%delz_inc )

--- a/tools/cubed_sphere_inc_mod.F90
+++ b/tools/cubed_sphere_inc_mod.F90
@@ -1,0 +1,69 @@
+module cubed_sphere_inc_mod
+
+  use tracer_manager_mod, only: get_tracer_index, get_number_tracers, get_tracer_names
+  use field_manager_mod,  only: MODEL_ATMOS
+  use fv_arrays_mod,      only: fv_atmos_type
+  use sim_nc_mod,         only: open_ncfile, get_var5_r4, check_var_exists, close_ncfile
+
+  implicit none
+  type increment_data_type
+    real, allocatable :: ua_inc(:,:,:)
+    real, allocatable :: va_inc(:,:,:)
+    real, allocatable :: temp_inc(:,:,:)
+    real, allocatable :: delp_inc(:,:,:)
+    real, allocatable :: delz_inc(:,:,:)
+    real, allocatable :: tracer_inc(:,:,:,:)
+  end type increment_data_type
+
+  public read_cubed_sphere_inc, increment_data_type
+
+  contains
+
+!----------------------------------------------------------------------------------------
+
+    subroutine read_cubed_sphere_inc(filename, increment_data, Atm)
+      character(*), intent(in)                 :: filename
+      type(increment_data_type), intent(inout) :: increment_data
+      type(fv_atmos_type), intent(in)          :: Atm
+
+      integer           :: isc, iec, jsc, jec, npz, itracer, ntracers, itile
+      character(len=64) :: tracer_name
+      integer           :: ncid, ncerr
+      
+      ! Get various dimensions
+      call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers)
+      isc = Atm%bd%isc
+      iec = Atm%bd%iec
+      jsc = Atm%bd%jsc
+      jec = Atm%bd%jec
+      npz = Atm%npz
+      itile = Atm%tile_of_mosaic
+
+      ! Open increment file
+      call open_ncfile( trim(filename), ncid )
+
+      ! Read increments
+      call get_var5_r4( ncid, 'u_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%ua_inc )
+      call get_var5_r4( ncid, 'v_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%va_inc )
+      call get_var5_r4( ncid, 'temp_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%temp_inc )
+      call get_var5_r4( ncid, 'delp_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%delp_inc )
+      if ( .not. Atm%flagstruct%hydrostatic ) then
+         call get_var5_r4( ncid, 'delz_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%delz_inc )
+      end if
+
+      ! Read tracer increments
+      do itracer = 1,ntracers
+         call get_tracer_names(MODEL_ATMOS, itracer, tracer_name)
+         call check_var_exists(ncid, trim(tracer_name)//'_inc', ncerr)
+         if ( ncerr == 0 ) then
+            call get_var5_r4( ncid, trim(tracer_name)//'_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%tracer_inc(:,:,:,itracer) )
+         end if
+      end do
+         
+      ! Close increment file
+      call close_ncfile(ncid)
+    
+  end subroutine read_cubed_sphere_inc
+
+!----------------------------------------------------------------------------------------
+end module cubed_sphere_inc_mod

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -66,6 +66,7 @@ module fv_iau_mod
   use fv_treat_da_inc_mod, only: remap_coef
   use tracer_manager_mod,  only: get_tracer_names,get_tracer_index, get_number_tracers
   use field_manager_mod,   only: MODEL_ATMOS
+  use module_get_cubed_sphere_inc, only : read_netcdf_inc, iau_internal_data_type
   implicit none
 
   private
@@ -84,14 +85,6 @@ module fv_iau_mod
   integer, allocatable :: tracer_indicies(:)
 
   real(kind=4), allocatable:: wk3(:,:,:)
-  type iau_internal_data_type
-    real,allocatable :: ua_inc(:,:,:)
-    real,allocatable :: va_inc(:,:,:)
-    real,allocatable :: temp_inc(:,:,:)
-    real,allocatable :: delp_inc(:,:,:)
-    real,allocatable :: delz_inc(:,:,:)
-    real,allocatable :: tracer_inc(:,:,:,:)
-  end type iau_internal_data_type
   type iau_external_data_type
     real,allocatable :: ua_inc(:,:,:)
     real,allocatable :: va_inc(:,:,:)
@@ -114,10 +107,11 @@ module fv_iau_mod
   public iau_external_data_type,IAU_initialize,getiauforcing
 
 contains
-subroutine IAU_initialize (IPD_Control, IAU_Data,Init_parm)
+subroutine IAU_initialize (IPD_Control, IAU_Data, Init_parm, Atm)
     type (IPD_control_type), intent(in) :: IPD_Control
     type (IAU_external_data_type), intent(inout) :: IAU_Data
     type (IPD_init_type),    intent(in) :: Init_parm
+    type (fv_atmos_type), intent(inout) :: Atm
     ! local
 
     character(len=128) :: fname
@@ -274,7 +268,11 @@ subroutine IAU_initialize (IPD_Control, IAU_Data,Init_parm)
        enddo
        iau_state%wt_normfact = (2*nstep+1)/normfact
     endif
-    call read_iau_forcing(IPD_Control,iau_state%inc1,'INPUT/'//trim(IPD_Control%iau_inc_files(1)))
+    if ( Atm%flagstruct%gaussian_increment ) then
+       call read_iau_forcing(IPD_Control,iau_state%inc1,'INPUT/'//trim(IPD_Control%iau_inc_files(1)))
+    else
+       call read_netcdf_inc('INPUT/'//trim(IPD_Control%iau_inc_files(1)), iau_state%inc1, Atm)
+    endif
     if (nfiles.EQ.1) then  ! only need to get incrments once since constant forcing over window
        call setiauforcing(IPD_Control,IAU_Data,iau_state%wt)
     endif
@@ -286,18 +284,23 @@ subroutine IAU_initialize (IPD_Control, IAU_Data,Init_parm)
        allocate (iau_state%inc2%delz_inc (is:ie, js:je, km))
        allocate (iau_state%inc2%tracer_inc(is:ie, js:je, km,ntracers))
        iau_state%hr2=IPD_Control%iaufhrs(2)
-       call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(2)))
+       if ( Atm%flagstruct%gaussian_increment ) then
+          call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(2)))
+       else
+          call read_netcdf_inc('INPUT/'//trim(IPD_Control%iau_inc_files(2)), iau_state%inc2, Atm)
+       endif
     endif
 !   print*,'in IAU init',dt,rdt
     IAU_data%drymassfixer = IPD_control%iau_drymassfixer
 
 end subroutine IAU_initialize
 
-subroutine getiauforcing(IPD_Control,IAU_Data)
+subroutine getiauforcing(IPD_Control,IAU_Data,Atm)
 
    implicit none
    type (IPD_control_type), intent(in) :: IPD_Control
    type(IAU_external_data_type),  intent(inout) :: IAU_Data
+   type (fv_atmos_type), intent(inout) :: Atm
    real(kind=kind_phys) t1,t2,sx,wx,wt,dtp
    integer n,i,j,k,sphum,kstep,nstep,itnext
 
@@ -371,7 +374,11 @@ subroutine getiauforcing(IPD_Control,IAU_Data)
             iau_state%hr2=IPD_Control%iaufhrs(itnext)
             iau_state%inc1=iau_state%inc2
             if (is_master()) print *,'reading next increment file',trim(IPD_Control%iau_inc_files(itnext))
-            call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(itnext)))
+            if ( Atm%flagstruct%gaussian_increment ) then
+               call read_iau_forcing(IPD_Control,iau_state%inc2,'INPUT/'//trim(IPD_Control%iau_inc_files(itnext)))
+            else
+               call read_netcdf_inc('INPUT/'//trim(IPD_Control%iau_inc_files(itnext)), iau_state%inc2, Atm)
+            endif
          endif
          call updateiauforcing(IPD_Control,IAU_Data,iau_state%wt)
       endif

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -66,7 +66,7 @@ module fv_iau_mod
   use fv_treat_da_inc_mod, only: remap_coef
   use tracer_manager_mod,  only: get_tracer_names,get_tracer_index, get_number_tracers
   use field_manager_mod,   only: MODEL_ATMOS
-  use module_cubed_sphere_inc, only : read_cubed_sphere_inc, increment_data_type
+  use cubed_sphere_inc_mod, only : read_cubed_sphere_inc, increment_data_type
   implicit none
 
   private

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -166,7 +166,7 @@ module fv_restart_mod
   use mpp_mod,             only: mpp_send, mpp_recv, mpp_sync_self, mpp_set_current_pelist, mpp_get_current_pelist, mpp_npes, mpp_pe, mpp_sync
   use mpp_domains_mod,     only: CENTER, CORNER, NORTH, EAST,  mpp_get_C2F_index, WEST, SOUTH
   use mpp_domains_mod,     only: mpp_global_field
-  use fv_treat_da_inc_mod, only: read_da_inc
+  use fv_treat_da_inc_mod, only: read_da_inc, read_da_inc_cubed_sphere
   use fms2_io_mod,         only: file_exists, set_filename_appendix, FmsNetcdfFile_t, open_file, close_file
   use coarse_grained_restart_files_mod, only: fv_io_write_restart_coarse
   use fv_regional_mod,     only: write_full_fields
@@ -372,9 +372,15 @@ contains
                    j = (Atm(n)%bd%jsc + Atm(n)%bd%jec)/2
                    k = Atm(n)%npz/2
                    if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
-                   call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
-                        Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
-                        isc, jsc, iec, jec )
+                   if ( Atm(n)%flagstruct%gaussian_increment ) then
+                      call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
+                           Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
+                           isc, jsc, iec, jec )
+                   else
+                      call read_da_inc_cubed_sphere(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
+                           Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
+                           isc, jsc, iec, jec )
+                   endif
                    if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
                 endif
                 !====== end PJP added DA functionailty======

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -371,18 +371,18 @@ contains
                    i = (Atm(n)%bd%isc + Atm(n)%bd%iec)/2
                    j = (Atm(n)%bd%jsc + Atm(n)%bd%jec)/2
                    k = Atm(n)%npz/2
-                   if ( Atm(n)%flagstruct%gaussian_increment ) then
-                      if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
-                      call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
-                           Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
-                           isc, jsc, iec, jec )
-                      if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
-                   else
+                   if ( Atm(n)%flagstruct%increment_file_on_native_grid ) then
                       if( is_master() ) write(*,*) 'Calling read_da_inc_cubed_sphere',Atm(n)%pt(i,j,k)
                       call read_da_inc_cubed_sphere(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
                            Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
                            isc, jsc, iec, jec )
                       if( is_master() ) write(*,*) 'Back from read_da_inc_cubed_sphere',Atm(n)%pt(i,j,k)
+                   else
+                      if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
+                      call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
+                           Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
+                           isc, jsc, iec, jec )
+                      if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
                    endif
                 endif
                 !====== end PJP added DA functionailty======

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -371,17 +371,19 @@ contains
                    i = (Atm(n)%bd%isc + Atm(n)%bd%iec)/2
                    j = (Atm(n)%bd%jsc + Atm(n)%bd%jec)/2
                    k = Atm(n)%npz/2
-                   if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
                    if ( Atm(n)%flagstruct%gaussian_increment ) then
+                      if( is_master() ) write(*,*) 'Calling read_da_inc',Atm(n)%pt(i,j,k)
                       call read_da_inc(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
                            Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
                            isc, jsc, iec, jec )
+                      if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
                    else
+                      if( is_master() ) write(*,*) 'Calling read_da_inc_cubed_sphere',Atm(n)%pt(i,j,k)
                       call read_da_inc_cubed_sphere(Atm(n), Atm(n)%domain, Atm(n)%bd, Atm(n)%npz, Atm(n)%ncnst, &
                            Atm(n)%u, Atm(n)%v, Atm(n)%q, Atm(n)%delp, Atm(n)%pt, Atm(n)%delz, isd, jsd, ied, jed, &
                            isc, jsc, iec, jec )
+                      if( is_master() ) write(*,*) 'Back from read_da_inc_cubed_sphere',Atm(n)%pt(i,j,k)
                    endif
-                   if( is_master() ) write(*,*) 'Back from read_da_inc',Atm(n)%pt(i,j,k)
                 endif
                 !====== end PJP added DA functionailty======
              endif

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -88,7 +88,7 @@ module fv_restart_mod
 !   </tr>
 !   <tr>
 !     <td>fv_treat_da_inc_mod</td>
-!     <td>read_da_inc</td>
+!     <td>read_da_inc, read_da_inc_cubed_sphere</td>
 !   </tr>
 !   <tr>
 !     <td>fv_timing_mod</td>

--- a/tools/fv_treat_da_inc.F90
+++ b/tools/fv_treat_da_inc.F90
@@ -159,7 +159,7 @@ module fv_treat_da_inc_mod
 contains
   !=============================================================================
   !>@brief The subroutine 'read_da_inc' reads the increments of the diagnostic variables
-  !! from the DA-generated files.
+  !! from the DA-generated files on a lot-lon grid.
   !>@details Additional support of prognostic variables such as tracers can be assessed
   !! and added upon request.
   !>@author Xi.Chen <xi.chen@noaa.gov>
@@ -472,6 +472,11 @@ contains
     !---------------------------------------------------------------------------
   end subroutine read_da_inc
 
+  !=============================================================================
+  !>@brief The subroutine 'read_da_inc_cubed_sphere' reads increments of diagnostic variables
+  !! from DA-generated files on the native cubed-sphere grid.
+  !>@author David.New <david.new@noaa.gov>     
+  !>@date 05/16/2024  
   subroutine read_da_inc_cubed_sphere(Atm, fv_domain, bd, npz_in, nq, &
                                       u, v, q, delp, pt, delz, &
                                       is_in, js_in, ie_in, je_in, isc_in, jsc_in, iec_in, jec_in)

--- a/tools/fv_treat_da_inc.F90
+++ b/tools/fv_treat_da_inc.F90
@@ -145,8 +145,8 @@ module fv_treat_da_inc_mod
                                get_var3_r4, &
                                get_var1_real, &
                                check_var_exists
-  use module_get_cubed_sphere_inc, only: read_netcdf_inc, &
-                                         iau_internal_data_type
+  use module_cubed_sphere_inc, only: read_cubed_sphere_inc, &
+                                     increment_data_type
   implicit none
   private
 
@@ -484,7 +484,7 @@ contains
     
     character(len=128)           :: fname
     integer                      :: sphum, liq_wat, spo, spo2, spo3, o3mr, i, j, k, itracer
-    type(iau_internal_data_type) :: increment_data
+    type(increment_data_type)    :: increment_data
     type(group_halo_update_type) :: i_pack(2)
     real                         :: ua_inc(is_in:ie_in, js_in:je_in, npz_in)
     real                         :: va_inc(is_in:ie_in, js_in:je_in, npz_in)
@@ -509,7 +509,7 @@ contains
     allocate(increment_data%tracer_inc(isc_in:iec_in,jsc_in:jec_in,npz_in,nq))
     
     ! Read increments
-    call read_netcdf_inc(fname, increment_data, Atm)
+    call read_cubed_sphere_inc(fname, increment_data, Atm)
 
     ! Wind increments
     ! ---------------

--- a/tools/fv_treat_da_inc.F90
+++ b/tools/fv_treat_da_inc.F90
@@ -126,12 +126,17 @@ module fv_treat_da_inc_mod
   use fv_grid_utils_mod, only: ptop_min, g_sum, &
                                mid_pt_sphere, get_unit_vect2, &
                                get_latlon_vector, inner_prod, &
-                               cubed_to_latlon
+                               cubed_to_latlon, &
+                               update2d_dwinds_phys, &
+                               update_dwinds_phys
   use fv_mp_mod,         only: is_master, &
                                fill_corners, &
                                YDir, &
                                mp_reduce_min, &
-                               mp_reduce_max
+                               mp_reduce_max, &
+                               group_halo_update_type, &
+                               start_group_halo_update, &
+                               complete_group_halo_update
   use sim_nc_mod,        only: open_ncfile, &
                                close_ncfile, &
                                get_ncdim1, &
@@ -140,10 +145,12 @@ module fv_treat_da_inc_mod
                                get_var3_r4, &
                                get_var1_real, &
                                check_var_exists
+  use module_get_cubed_sphere_inc, only: read_netcdf_inc, &
+                                         iau_internal_data_type
   implicit none
   private
 
-  public :: read_da_inc,remap_coef
+  public :: read_da_inc, read_da_inc_cubed_sphere, remap_coef
 
 contains
   !=============================================================================
@@ -461,6 +468,149 @@ contains
     !---------------------------------------------------------------------------
   end subroutine read_da_inc
 
+  subroutine read_da_inc_cubed_sphere(Atm, fv_domain, bd, npz_in, nq, u, v, q, delp, pt, delz, &
+                                      is_in, js_in, ie_in, je_in, isc_in, jsc_in, iec_in, jec_in)
+    type(fv_atmos_type),       intent(in)    :: Atm
+    type(domain2d),            intent(inout) :: fv_domain
+    type(fv_grid_bounds_type), intent(in)    :: bd
+    integer,                   intent(in)    :: npz_in, nq, is_in, js_in, ie_in, je_in, isc_in, jsc_in, iec_in, jec_in
+    real, intent(inout) :: u(is_in:ie_in, js_in:je_in+1, npz_in)  ! D grid zonal wind (m/s)
+    real, intent(inout) :: v(is_in:ie_in+1, js_in:je_in, npz_in)  ! D grid meridional wind (m/s)
+    real, intent(inout) :: delp(is_in:ie_in, js_in:je_in, npz_in)  ! pressure thickness (pascal)
+    real, intent(inout) :: pt(  is_in:ie_in, js_in:je_in, npz_in)  ! temperature (K)
+    real, intent(inout) :: q(   is_in:ie_in, js_in:je_in, npz_in, nq)  !
+    real, intent(inout) :: delz(isc_in:iec_in, jsc_in:jec_in, npz_in)  !
+    
+    character(len=128)           :: fname
+    integer                      :: sphum, liq_wat, spo, spo2, spo3, o3mr, i,j, k
+    type(iau_internal_data_type) :: increment_data
+    type(group_halo_update_type) :: i_pack(2)
+
+    ! Get increment filename
+    fname = 'INPUT/'//Atm%flagstruct%res_latlon_dynamics
+
+    ! Ensure file exists
+    if ( .not. file_exists(fname) ) then
+      call mpp_error(FATAL,'==> Error in read_da_inc: Expected file '&
+          //trim(fname)//' for DA increment does not exist')
+    endif
+
+    ! Read increments
+    call read_netcdf_inc(fname, increment_data, Atm)
+
+    ! Wind increments
+    ! ---------------
+
+    ! Start halo update
+    if ( Atm%gridstruct%square_domain ) then
+       call start_group_halo_update(i_pack(1), increment_data%ua_inc, fv_domain, whalo=1, ehalo=1, shalo=1, nhalo=1, complete=.false.)
+       call start_group_halo_update(i_pack(1), increment_data%va_inc, fv_domain, whalo=1, ehalo=1, shalo=1, nhalo=1, complete=.true.)
+    else
+       call start_group_halo_update(i_pack(1), increment_data%ua_inc, fv_domain, complete=.false.)
+       call start_group_halo_update(i_pack(1), increment_data%va_inc, fv_domain, complete=.true.)
+    endif
+
+    if ( Atm%flagstruct%dwind_2d ) then
+       ! Apply A-grid wind increments to D-grid winds for case of dwind_2d
+       call update2d_dwinds_phys(is_in, ie_in, js_in, je_in, bd%isd, bd%ied, bd%jsd, bd%jed, &
+                                 1., increment_data%ua_inc, increment_data%va_inc, u, v, &
+                                 Atm%gridstruct, Atm%npx, Atm%npy, npz_in, fv_domain)
+    else
+       ! Complete halo update
+       call complete_group_halo_update(i_pack(1), fv_domain)
+
+       ! Treat increment boundary conditions for case of regional grid                                                                         
+       if (Atm%gridstruct%regional) then
+          ! Edges
+          if (is_in == 1) then
+             do k=1,npz_in
+                do j = js_in,je_in
+                   increment_data%ua_inc(is_in-1,j,k) = increment_data%ua_inc(is_in,j,k)
+                   increment_data%va_inc(is_in-1,j,k) = increment_data%va_inc(is_in,j,k)
+                enddo
+             enddo
+          endif
+          if (ie_in == Atm%npx) then
+             do k=1,npz_in
+                do j = js_in,je_in
+                   increment_data%ua_inc(ie_in+1,j,k) = increment_data%ua_inc(ie_in,j,k)
+                   increment_data%va_inc(ie_in+1,j,k) = increment_data%va_inc(ie_in,j,k)
+                enddo
+             enddo
+          endif
+          if (js_in == 1) then
+             do k=1,npz_in
+                do i = is_in,ie_in
+                   increment_data%ua_inc(i,js_in-1,k) = increment_data%ua_inc(i,js_in,k)
+                   increment_data%va_inc(i,js_in-1,k) = increment_data%va_inc(i,js_in,k)
+                enddo
+             enddo
+          endif
+          if (je_in == Atm%npy) then
+             do k=1,npz_in
+                do i = is_in,ie_in
+                   increment_data%ua_inc(i,je_in+1,k) = increment_data%ua_inc(i,je_in,k)
+                   increment_data%va_inc(i,je_in+1,k) = increment_data%va_inc(i,je_in,k)
+                enddo
+             enddo
+          endif
+
+          ! corners
+          do k=1,npz_in
+             if (is_in == 1 .and. js_in == 1) then
+                increment_data%ua_inc(is_in-1,js_in-1,k) = increment_data%ua_inc(is_in,js_in,k)
+                increment_data%va_inc(is_in-1,js_in-1,k) = increment_data%va_inc(is_in,js_in,k)
+             elseif (is_in == 1 .and. je_in == Atm%npy) then
+                increment_data%ua_inc(is_in-1,je_in+1,k) = increment_data%ua_inc(is_in,je_in,k)
+                increment_data%va_inc(is_in-1,je_in+1,k) = increment_data%va_inc(is_in,je_in,k)
+             elseif (ie_in == Atm%npx .and. js_in == 1) then
+                increment_data%ua_inc(ie_in+1,js_in-1,k) = increment_data%ua_inc(ie_in,je_in,k)
+                increment_data%va_inc(ie_in+1,js_in-1,k) = increment_data%va_inc(ie_in,je_in,k)
+             elseif (ie_in == Atm%npx .and. je_in == Atm%npy) then
+                increment_data%ua_inc(ie_in+1,je_in+1,k) = increment_data%ua_inc(ie_in,je_in,k)
+                increment_data%va_inc(ie_in+1,je_in+1,k) = increment_data%va_inc(ie_in,je_in,k)
+             endif
+          enddo
+       endif
+
+       ! Apply A-grid wind increments to D-grid winds
+       call update_dwinds_phys(is_in, ie_in, js_in, je_in, bd%isd, bd%ied, bd%jsd, bd%jed, &
+                               1., increment_data%ua_inc, increment_data%va_inc, u, v, &
+                               Atm%gridstruct, Atm%npx, Atm%npy, npz_in, fv_domain)
+    endif
+       
+    ! Remaining increments
+    ! --------------------
+    
+    ! Get tracer indices
+    sphum   = get_tracer_index(MODEL_ATMOS, 'sphum')
+    liq_wat = get_tracer_index(MODEL_ATMOS, 'liq_wat')
+#ifdef MULTI_GASES
+    spo     = get_tracer_index(MODEL_ATMOS, 'spo')
+    spo2    = get_tracer_index(MODEL_ATMOS, 'spo2')
+    spo3    = get_tracer_index(MODEL_ATMOS, 'spo3')
+#else
+    o3mr    = get_tracer_index(MODEL_ATMOS, 'o3mr')
+#endif
+
+    ! Apply increments
+    pt   = pt   + increment_data%temp_inc
+    delp = delp + increment_data%delp_inc
+    if ( .not. Atm%flagstruct%hydrostatic ) then
+       delz = delz + increment_data%delz_inc
+    endif
+    q(:,:,:,sphum)   = q(:,:,:,sphum)   + increment_data%tracer_inc(:,:,:,sphum)
+    q(:,:,:,liq_wat) = q(:,:,:,liq_wat) + increment_data%tracer_inc(:,:,:,liq_wat)
+#ifdef MULTI_GASES
+    q(:,:,:,spo)     = q(:,:,:,spo)     + increment_data%tracer_inc(:,:,:,spo)
+    q(:,:,:,spo2)    = q(:,:,:,spo2)    + increment_data%tracer_inc(:,:,:,spo2)
+    q(:,:,:,spo3)    = q(:,:,:,spo3)    + increment_data%tracer_inc(:,:,:,spo3)
+#else
+    q(:,:,:,o3mr)    = q(:,:,:,o3mr)    + increment_data%tracer_inc(:,:,:,o3mr)
+#endif
+
+  end subroutine read_da_inc_cubed_sphere
+          
   !=============================================================================
   !>@brief The subroutine 'remap_coef' calculates the coefficients for horizonal regridding.
 

--- a/tools/fv_treat_da_inc.F90
+++ b/tools/fv_treat_da_inc.F90
@@ -103,6 +103,10 @@ module fv_treat_da_inc_mod
 !     <td>tracer_manager_mod</td>
 !     <td>get_tracer_names, get_number_tracers, get_tracer_index</td>
 !   </tr>
+!   <tr>
+!     <td>cubed_sphere_inc_mod</td>
+!     <td>read_cubed_sphere_inc, increment_data_type</td>
+!   </tr>  
 ! </table>
 
   use fms2_io_mod,       only: file_exists
@@ -145,8 +149,8 @@ module fv_treat_da_inc_mod
                                get_var3_r4, &
                                get_var1_real, &
                                check_var_exists
-  use module_cubed_sphere_inc, only: read_cubed_sphere_inc, &
-                                     increment_data_type
+  use cubed_sphere_inc_mod, only: read_cubed_sphere_inc, &
+                                  increment_data_type
   implicit none
   private
 
@@ -601,7 +605,7 @@ contains
                                1., ua_inc, va_inc, u, v, &
                                Atm%gridstruct, Atm%npx, Atm%npy, npz_in, fv_domain)
     endif
-       
+
     ! Remaining increments
     ! --------------------
     

--- a/tools/module_cubed_sphere_inc.F90
+++ b/tools/module_cubed_sphere_inc.F90
@@ -1,0 +1,69 @@
+module module_cubed_sphere_inc
+
+  use tracer_manager_mod, only: get_tracer_index, get_number_tracers, get_tracer_names
+  use field_manager_mod,  only: MODEL_ATMOS
+  use fv_arrays_mod,      only: fv_atmos_type
+  use sim_nc_mod,         only: open_ncfile, get_var5_r4, check_var_exists, close_ncfile
+
+  implicit none
+  type increment_data_type
+    real, allocatable :: ua_inc(:,:,:)
+    real, allocatable :: va_inc(:,:,:)
+    real, allocatable :: temp_inc(:,:,:)
+    real, allocatable :: delp_inc(:,:,:)
+    real, allocatable :: delz_inc(:,:,:)
+    real, allocatable :: tracer_inc(:,:,:,:)
+  end type increment_data_type
+
+  public read_cubed_sphere_inc, increment_data_type
+
+  contains
+
+!----------------------------------------------------------------------------------------
+
+    subroutine read_cubed_sphere_inc(filename, increment_data, Atm)
+      character(*), intent(in)                 :: filename
+      type(increment_data_type), intent(inout) :: increment_data
+      type(fv_atmos_type), intent(in)          :: Atm
+
+      integer           :: isc, iec, jsc, jec, npz, itracer, ntracers, itile
+      character(len=64) :: tracer_name
+      integer           :: ncid, ncerr
+      
+      ! Get various dimensions
+      call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers)
+      isc = Atm%bd%isc
+      iec = Atm%bd%iec
+      jsc = Atm%bd%jsc
+      jec = Atm%bd%jec
+      npz = Atm%npz
+      itile = Atm%tile_of_mosaic
+
+      ! Open increment file
+      call open_ncfile( trim(filename), ncid )
+
+      ! Read increments
+      call get_var5_r4( ncid, 'u_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%ua_inc )
+      call get_var5_r4( ncid, 'v_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%va_inc )
+      call get_var5_r4( ncid, 'temp_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%temp_inc )
+      call get_var5_r4( ncid, 'delp_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%delp_inc )
+      if ( .not. Atm%flagstruct%hydrostatic ) then
+         call get_var5_r4( ncid, 'delz_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%delz_inc )
+      end if
+
+      ! Read tracer increments
+      do itracer = 1,ntracers
+         call get_tracer_names(MODEL_ATMOS, itracer, tracer_name)
+         call check_var_exists(ncid, trim(tracer_name)//'_inc', ncerr)
+         if ( ncerr == 0 ) then
+            call get_var5_r4( ncid, trim(tracer_name)//'_inc', isc,iec, jsc,jec, 1,npz, itile, 1, increment_data%tracer_inc(:,:,:,itracer) )
+         end if
+      end do
+         
+      ! Close increment file
+      call close_ncfile(ncid)
+    
+  end subroutine read_cubed_sphere_inc
+
+!----------------------------------------------------------------------------------------
+end module module_cubed_sphere_inc

--- a/tools/module_get_cubed_sphere_inc.F90
+++ b/tools/module_get_cubed_sphere_inc.F90
@@ -1,0 +1,84 @@
+#define NC_ERR_STOP(status) \
+    if (status /= nf90_noerr) write(0,*) "file: ", __FILE__, " line: ", __LINE__, trim(nf90_strerror(status)); \
+    if (status /= nf90_noerr) call ESMF_Finalize(endflag=ESMF_END_ABORT)
+
+module module_get_cubed_sphere_inc
+
+  use netcdf
+  use esmf
+  use mpp_mod,            only: mpp_pe, mpp_get_current_pelist
+  use tracer_manager_mod, only: get_tracer_index, get_number_tracers, get_tracer_names
+  use field_manager_mod,  only: MODEL_ATMOS
+  use CCPP_data,          only: GFS_control
+  use time_manager_mod,   only: time_type, get_time, set_time
+  use fv_arrays_mod,      only: fv_atmos_type
+  use fms2_io_mod,        only: open_file, close_file, read_data, variable_exists, FmsNetcdfFile_t
+  use mpi
+
+  implicit none
+  type iau_internal_data_type
+    real,allocatable :: ua_inc(:,:,:)
+    real,allocatable :: va_inc(:,:,:)
+    real,allocatable :: temp_inc(:,:,:)
+    real,allocatable :: delp_inc(:,:,:)
+    real,allocatable :: delz_inc(:,:,:)
+    real,allocatable :: tracer_inc(:,:,:,:)
+  end type iau_internal_data_type
+
+  public read_netcdf_inc, iau_internal_data_type
+
+  contains
+
+!----------------------------------------------------------------------------------------
+
+    subroutine read_netcdf_inc(filename, increment_data, Atm)
+      character(*), intent(in)                    :: filename
+      type(iau_internal_data_type), intent(inout) :: increment_data
+      type(fv_atmos_type), intent(in)             :: Atm
+
+      type(FmsNetcdfFile_t) :: fileobj
+      integer               :: is, ie, js, je, km, itracer, ntracers, itile
+      integer, dimension(4) :: corner, edge_lengths
+      character(len=64)     :: tracer_name
+      
+      ! Get various dimensions
+      call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers)
+      is    = GFS_control%isc
+      js    = GFS_control%jsc
+      ie    = is + GFS_control%nx - 1
+      je    = js + GFS_Control%ny - 1
+      km    = GFS_Control%levs
+      itile = Atm%tile_of_mosaic
+      
+      ! Open increment file
+      if ( open_file(fileobj, trim(filename), "read", pelist=Atm%pelist) ) then
+
+         !
+         corner       = (/ itile, 1,  js,      is /)
+         edge_lengths = (/ 1,     km, je-js+1, ie-is+1 /) 
+       
+         ! Read increments
+         call read_data(fileobj, 'u_inc',    increment_data%ua_inc,   corner=corner, edge_lengths=edge_lengths)
+         call read_data(fileobj, 'v_inc',    increment_data%va_inc,   corner=corner, edge_lengths=edge_lengths)
+         call read_data(fileobj, 'T_inc',    increment_data%temp_inc, corner=corner, edge_lengths=edge_lengths)
+         call read_data(fileobj, 'delp_inc', increment_data%delp_inc, corner=corner, edge_lengths=edge_lengths)
+         call read_data(fileobj, 'delz_inc', increment_data%delz_inc, corner=corner, edge_lengths=edge_lengths)
+
+         ! Read tracer increments
+         do itracer = 1,ntracers
+            call get_tracer_names(MODEL_ATMOS, itracer, tracer_name)
+            if ( variable_exists(fileobj, tracer_name//'_inc') ) then
+               call read_data(fileobj, tracer_name//'_inc', increment_data%tracer_inc(:,:,:,itracer), &
+                    corner=corner, edge_lengths=edge_lengths)
+            end if
+         end do
+
+         ! Close increment file
+         call close_file(fileobj)
+         
+      end if
+    
+  end subroutine read_netcdf_inc
+    
+!----------------------------------------------------------------------------------------
+end module module_get_cubed_sphere_inc

--- a/tools/sim_nc_mod.F90
+++ b/tools/sim_nc_mod.F90
@@ -47,7 +47,7 @@ module sim_nc_mod
  public  open_ncfile, close_ncfile, get_ncdim1, get_var1_double, get_var2_double,   &
          get_var3_real, get_var3_double, get_var3_r4, get_var2_real, get_var2_r4,   &
          handle_err, check_var, get_var1_real, get_var_att_double, &
-         check_var_exists
+         check_var_exists, get_var5_r4
 
  contains
 
@@ -339,6 +339,66 @@ module sim_nc_mod
       if (status .ne. NF_NOERR) call handle_err('get_var4_double get_vara_double '//var4_name,status)
 
       end subroutine get_var4_double
+
+      subroutine get_var5_r4( ncid, var5_name, is,ie, js,je, ks,ke, ntile, ntime, var5 )
+      implicit         none
+#include <netcdf.inc>
+      integer, intent(in):: ncid
+      character*(*), intent(in)::  var5_name
+      integer, intent(in):: is, ie, js, je, ks, ke, ntile, ntime
+      real*4, intent(out):: var5(is:ie,js:je,ks:ke)
+      integer:: status, var5id
+      integer:: start(5), icount(5)
+
+      start(1) = is
+      start(2) = js
+      start(3) = ks
+      start(4) = ntile
+      start(5) = ntime
+
+      icount(1) = ie - is + 1
+      icount(2) = je - js + 1
+      icount(3) = ke - ks + 1
+      icount(4) = 1           ! one tile at a time
+      icount(5) = 1           ! one time level at a time
+
+      status = nf_inq_varid (ncid, var5_name, var5id)
+
+      status = nf_get_vara_real(ncid, var5id, start, icount, var5)
+
+      if (status .ne. NF_NOERR) call handle_err('get_var5_r4 get_vara_real '//var5_name,status)
+
+      end subroutine get_var5_r4
+
+      subroutine get_var5_double( ncid, var5_name, is,ie, js,je, ks,ke, ntile, ntime, var5 )
+      implicit         none
+#include <netcdf.inc>
+      integer, intent(in):: ncid
+      character*(*), intent(in)::  var5_name
+      integer, intent(in):: is, ie, js, je, ks, ke, ntile, ntime
+      real*8, intent(out):: var5(is:ie,js:je,ks:ke)
+      integer:: status, var5id
+      integer:: start(5), icount(5)
+
+      start(1) = is
+      start(2) = js
+      start(3) = ks
+      start(4) = ntile
+      start(5) = ntime
+
+      icount(1) = ie - is + 1
+      icount(2) = je - js + 1
+      icount(3) = ke - ks + 1
+      icount(4) = 1           ! one tile at a time
+      icount(5) = 1           ! one time level at a time
+
+      status = nf_inq_varid (ncid, var5_name, var5id)
+
+      status = nf_get_vara_double(ncid, var5id, start, icount, var5)
+
+      if (status .ne. NF_NOERR) call handle_err('get_var5_real get_vara_real '//var5_name,status)
+
+      end subroutine get_var5_double
 !------------------------------------------------------------------------
 
       subroutine get_real3( ncid, var4_name, im, jm, nt, var4 )


### PR DESCRIPTION
**Description**

This PR adds the ability to read increments on the native cubed sphere grid, both inside and outside the IAU framework. This option can be turned on by an input namelist option, "increment_file_on_native_grid", which defaults to .false.. 

The motivation for this PR is that we would like to read cubed sphere increments in the Global Workflow used by NOAA-EMC for the new JEDI DA system.

This PR is based off of another PR, #274, but I'm opening a new one, because I had to make so many changes to allow increments outside of the IAU framework, since IAU is not yet implemented in JEDI.

Overview of code changes:

A new module, "cubed_sphere_inc_mod.F90", has been added to the "tools" directory, and it has a subroutine, "read_cubed_sphere_inc", that will read the increment into an "increment_data_type" structure. This structure was formerly the "iau_internal_data_type" data structure in "fv_iau_mod.F90", but I've moved it into the new module to avoid circular dependencies and renamed it to reflect the fact that it's not just for IAU.

"read_cubed_sphere_inc" is called in either "fv_iau_mod.F90" for "fv_treat_da_inc.F90", depending on whether or not IAU is used. If not using IAU, a new subroutine, "read_da_inc_cubed_sphere", in "fv_treat_da_inc.F90" is called in "fv_restart.F90" to read and apply the increment. This involves some halo updates and a physics call so the A-grid wind increment can be applied to the D-grid wind.

Fixes # (issue)

N/A

**How Has This Been Tested?**

I ran a few of sets of experiments that involved three C96, 6-hour forecasts with identical initial conditions. These experiments were run on RDHPCS Hera.

First, I used JEDI to produce two increments, identical except that one was on the native grid and one was interpolated to the Gaussian grid, and then I ran two forecasts, one for each increment (not with IAU). In the third experiment, I ran the forecast without an increment. I then subtracted the free (no increment) forecast model fields from the model fields of the forecasts using the increments. This allows me to isolate the impact of the increments on the forecast. Finally, I plotted the resulting model fields and their differences and verified visually that the impact of the increments were identical in terms of large-scale patterns. Naturally there are differences between the two forecasts because of interpolation, but these appeared to produce mostly noise. But the fact that there are (expected) differences is why I had to verify my results visually.

The following is a plot of "o3mr" at model level 20 (statosphere), using OMI satellite observations for the increment:

![Figure_1](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/assets/134300700/8fa9e75a-da7e-4747-b0df-06249506de86)

Here is another plot of "ua" at model level 20, using satwind observations for the increment:

![Figure_2](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/assets/134300700/d9fb3df0-8622-4f5b-a80a-355e0053ce07)

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
