### PR TITLE
Implement fine and coarse `t_dt_diabatic` and `qv_dt_diabatic` diagnostics

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -778,6 +778,26 @@ contains
              Atm(n)%nudge_diag%nudge_v_dt(isc:iec,jsc:jec,1:npz) = 0.0
           endif
 
+          id_t_dt_diabatic = register_diag_field ( trim(field), 'T_dt_diabatic', axes(1:3), Time,           &
+               'temperature tendency from diabatic processes (t_dt_phys + t_dt_gfdlmp)', 'K/s', missing_value=missing_value )
+          if (id_t_dt_diabatic > 0) then
+             if (.not. allocated(Atm(n)%phys_diag%phys_t_dt)) then
+                allocate(Atm(n)%phys_diag%phys_t_dt(isc:iec,jsc:jec,npz))
+             endif
+             if (.not. allocated(Atm(n)%inline_mp%t_dt)) then
+                allocate(Atm(n)%inline_mp%t_dt(isc:iec,jsc:jec,npz))
+             endif
+          endif
+          id_qv_dt_diabatic = register_diag_field ( trim(field), 'qv_dt_diabatic', axes(1:3), Time,           &
+               'temperature tendency from diabatic processes (qv_dt_phys + qv_dt_gfdlmp)', 'kg/kg/s', missing_value=missing_value )
+          if (id_qv_dt_diabatic > 0) then
+             if (.not. allocated(Atm(n)%phys_diag%phys_qv_dt)) then
+                allocate(Atm(n)%phys_diag%phys_qv_dt(isc:iec,jsc:jec,npz))
+             endif
+             if (.not. allocated(Atm(n)%inline_mp%qv_dt)) then
+                allocate(Atm(n)%inline_mp%qv_dt(isc:iec,jsc:jec,npz))
+             endif
+          endif
        endif
 
 !
@@ -1810,6 +1830,11 @@ contains
        if (idiag%id_u_dt_sg > 0) used=send_data(idiag%id_u_dt_sg,  Atm(n)%sg_diag%u_dt(isc:iec,jsc:jec,1:npz), Time)
        if (idiag%id_v_dt_sg > 0) used=send_data(idiag%id_v_dt_sg,  Atm(n)%sg_diag%v_dt(isc:iec,jsc:jec,1:npz), Time)
        if (idiag%id_qv_dt_sg > 0) used=send_data(idiag%id_qv_dt_sg,  Atm(n)%sg_diag%qv_dt(isc:iec,jsc:jec,1:npz), Time)
+
+       if (id_t_dt_diabatic > 0) used=send_data(id_t_dt_diabatic, Atm(n)%phys_diag%phys_t_dt(isc:iec,jsc:jec,1:npz) + &
+                                                Atm(n)%inline_mp%t_dt(isc:iec,jsc:jec,1:npz), Time)
+       if (id_qv_dt_diabatic > 0) used=send_data(id_qv_dt_diabatic, Atm(n)%phys_diag%phys_qv_dt(isc:iec,jsc:jec,1:npz) + &
+                                                Atm(n)%inline_mp%qv_dt(isc:iec,jsc:jec,1:npz), Time)
 
        if(id_c15>0 .or. id_c25>0 .or. id_c35>0 .or. id_c45>0) then
           call wind_max(isc, iec, jsc, jec ,isd, ied, jsd, jed, Atm(n)%ua(isc:iec,jsc:jec,npz),   &

--- a/tools/fv_diagnostics.h
+++ b/tools/fv_diagnostics.h
@@ -95,6 +95,7 @@
      integer :: id_qr_dt_phys, id_qg_dt_phys, id_qs_dt_phys
      integer :: id_liq_wat_dt_phys, id_ice_wat_dt_phys
      integer :: id_intqv, id_intql, id_intqi, id_intqr, id_intqs, id_intqg
+     integer :: id_t_dt_diabatic, id_qv_dt_diabatic
 
 ! ESM/CM 3-D diagostics
      integer :: id_uq, id_vq, id_wq, id_iuq, id_ivq, id_iwq,   & ! moisture flux & vertical integral


### PR DESCRIPTION
**Description**

This PR adds fine and coarse `t_dt_diabatic` and `qv_dt_diabatic` diagnostics.  These represent `t_dt_phys + t_dt_gfdlmp` and `qv_dt_phys + qv_dt_gfdlmp`, respectively.  Since we are often only interested in the total diabatic tendencies of these fields, it is more space-efficient to compute the sum online instead of offline.

**How Has This Been Tested?**

This been tested by outputting `t_dt_diabatic`, `t_dt_phys`, `t_dt_gfdlmp`, `qv_dt_diabatic`, `qv_dt_phys`, and `qv_dt_gfdlmp` and verifying that `t_dt_diabatic = t_dt_phys + t_dt_gfdlmp` and `qv_dt_diabatic = qv_dt_phys + qv_dt_gfdlmp` offline.  We have done the same for the `_coarse` versions of these diagnostics with both coarse-graining strategies implemented in this version of the code[^1].

We have also tested that the code runs and produces correct results if only `t_dt_diabatic` and `qv_dt_diabatic`, or only `t_dt_diabatic_coarse` and `qv_dt_diabatic_coarse` are output.

Finally, we have tested to make sure that coarse-graining results for other 3D fields have remained unchanged.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

[^1]: For pressure-level coarsening it is only approximate, since computing the sum and then coarsening produces different results than coarsening and then computing the sum.