### PR TITLE
Adjust do loop bounds in a2b_ord2 to prevent reading from uninitialized memory

### DIFF
--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -10,7 +10,7 @@ set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverrid
 
 set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3")
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays")
 
 set(CMAKE_Fortran_LINK_FLAGS "")
 

--- a/model/a2b_edge.F90
+++ b/model/a2b_edge.F90
@@ -377,8 +377,8 @@ contains
 
        if (gridstruct%bounded_domain) then
 
-          do j=js-2,je+1+2
-             do i=is-2,ie+1+2
+          do j=js,je+1
+             do i=is,ie+1
                 qout(i,j) = 0.25*(qin(i-1,j-1)+qin(i,j-1)+qin(i-1,j)+qin(i,j))
              enddo
           enddo


### PR DESCRIPTION
**Description**

This PR fixes occasional model crashes in debug mode caused by floating-point exception in subroutine `a2b_ord2` in `model/a2b_edge.F90`. See issue #346 for details.

In subroutine `a2b_ord2` do loop bounds are changed to avoid reading from uninitialized elements of `qin` array. 

Intel Fortran compiler flag (`-init=snan,arrays`) has been added to debug flags.

Fixes #346

**How Has This Been Tested?**

Several debug ufs-weather-model regression tests have been run on Hera and few other NOAA systems successfully. I will run full regression test on Hera.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
