### PR TITLE
Minor corrections for mixed mode support in AM5

### DIFF
--- a/driver/GFDL/include/atmosphere.inc
+++ b/driver/GFDL/include/atmosphere.inc
@@ -13,13 +13,21 @@
                                & in the Cubed Sphere')
     endif
 
-    do j=jsc,jec+1
-       do i=isc,iec+1
-          blon(i-isc+1,j-jsc+1) = _DBL_(_RL_(Atm(mygrid)%gridstruct%grid(i,j,1)))
-          blat(i-isc+1,j-jsc+1) = _DBL_(_RL_(Atm(mygrid)%gridstruct%grid(i,j,2)))
-       enddo
-    end do
-
+    if (ATMOSPHERE_KIND_ .eq. r8_kind) then
+      do j=jsc,jec+1
+        do i=isc,iec+1
+          blon(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid_64(i,j,1)
+          blat(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid_64(i,j,2)
+        enddo
+      end do
+    else
+      do j=jsc,jec+1
+        do i=isc,iec+1
+          blon(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid(i,j,1)
+          blat(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid(i,j,2)
+        enddo
+      end do
+    endif
  end subroutine ATMOSPHERE_BOUNDARY_
 
  subroutine ATMOSPHERE_PREF_ (p_ref)
@@ -56,8 +64,8 @@
            p_surf(i,j) = _DBL_(_RL_(Atm(mygrid)%ps(i,j)))
            t_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,npz)))
            p_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%delp(i,j,npz)/(Atm(mygrid)%peln(i,npz+1,j)-Atm(mygrid)%peln(i,npz,j))))
-           z_bot(i,j) = rrg*t_bot(i,j)*_DBL_(_RL_(1.+zvir*Atm(mygrid)%q(i,j,npz,sphum))) *  &
-                        _DBL_(_RL_(1. - Atm(mygrid)%pe(i,npz,j)/p_bot(i,j)))
+           z_bot(i,j) = rrg*t_bot(i,j)*_DBL_(_RL_((1.+zvir*Atm(mygrid)%q(i,j,npz,sphum)))) *  &
+                        _DBL_(_RL_((1. - Atm(mygrid)%pe(i,npz,j)/p_bot(i,j))))
         enddo
      enddo
 

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -21,9 +21,9 @@
 
 module fv_grid_tools_mod
 #ifdef OVERLOAD_R4
-  use constants_mod,  only: grav, pi=>pi_8
+  use constantsR4_mod,  only: grav, pi=>pi_8
 #else
-  use constantsR4_mod,only: grav, pi=>pi_8
+  use constants_mod,only: grav, pi=>pi_8
 #endif
   use fv_arrays_mod,  only: radius, omega ! scaled for small earth
 !  use test_cases_mod, only: small_earth_scale
@@ -89,7 +89,7 @@ contains
     integer,             intent(IN)    :: ng
 
     type(FmsNetcdfFile_t) :: Grid_input
-    real, allocatable, dimension(:,:)  :: tmpx, tmpy
+    real(kind=R_GRID), allocatable, dimension(:,:)  :: tmpx, tmpy
     real(kind=R_GRID), pointer, dimension(:,:,:)    :: grid
     character(len=128)                 :: units = ""
     character(len=256)                 :: atm_mosaic, atm_hgrid, grid_form


### PR DESCRIPTION
**Description**
This PR includes some fixes needed for mixed mode support in AM5:

1. Return the correct version of the `lon` and `lat` in `atmosphere_boundary`
2. Fix a typo so that the correct constants in `fv_grid_tools.F90` are included
3. Added missing parenthesis when setting `z_bot` in `get_bottom_mass`, this was causing answer changes when using the non-mixed precision version of am5

Fixes # (issue)

**How Has This Been Tested?**
Ran AM5 with and without mixed precision

**Checklist:**
Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
