### PR TITLE
allows mix precision compilation

### DIFF
--- a/driver/SHiELDFULL/include/atmosphere.inc
+++ b/driver/SHiELDFULL/include/atmosphere.inc
@@ -1,0 +1,169 @@
+ subroutine ATMOSPHERE_GRID_BDRY_ (blon, blat, global)
+!---------------------------------------------------------------
+!    returns the longitude and latitude grid box edges
+!    for either the local PEs grid (default) or the global grid
+!---------------------------------------------------------------
+    real(ATMOSPHERE_KIND_),    intent(out) :: blon(:,:), blat(:,:)   ! Unit: radian
+    logical, intent(in), optional :: global
+! Local data:
+    integer i,j
+
+    if( PRESENT(global) ) then
+      if (global) call mpp_error(FATAL, '==> global grid is no longer available &
+                               & in the Cubed Sphere')
+    endif
+
+    if (ATMOSPHERE_KIND_ .eq. r8_kind) then
+      do j=jsc,jec+1
+        do i=isc,iec+1
+          blon(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid_64(i,j,1)
+          blat(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid_64(i,j,2)
+        enddo
+      end do
+    else
+      do j=jsc,jec+1
+        do i=isc,iec+1
+          blon(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid(i,j,1)
+          blat(i-isc+1,j-jsc+1) = Atm(mygrid)%gridstruct%grid(i,j,2)
+        enddo
+      end do
+    endif
+ end subroutine ATMOSPHERE_GRID_BDRY_
+
+ subroutine ATMOSPHERE_PREF_ (p_ref)
+   real(ATMOSPHERE_KIND_), dimension(:,:), intent(inout) :: p_ref
+
+   p_ref = _DBL_(_RL_(pref))
+
+ end subroutine ATMOSPHERE_PREF_
+
+  subroutine ATMOSPHERE_CELL_AREA_  (area_out)
+   real(ATMOSPHERE_KIND_), dimension(:,:),  intent(out)          :: area_out
+
+   area_out(1:iec-isc+1, 1:jec-jsc+1) =  _DBL_(_RL_(Atm(mygrid)%gridstruct%area (isc:iec,jsc:jec)))
+
+ end subroutine ATMOSPHERE_CELL_AREA_
+
+ subroutine GET_BOTTOM_MASS_ ( t_bot, tr_bot, p_bot, z_bot, p_surf, slp )
+  !--------------------------------------------------------------
+  ! returns temp, sphum, pres, height at the lowest model level
+  ! and surface pressure
+  !--------------------------------------------------------------
+     real(ATMOSPHERE_KIND_), intent(out), dimension(isc:iec,jsc:jec):: t_bot, p_bot, z_bot, p_surf
+     real(ATMOSPHERE_KIND_), intent(out), optional, dimension(isc:iec,jsc:jec):: slp
+     real(ATMOSPHERE_KIND_), intent(out), dimension(isc:iec,jsc:jec,nq):: tr_bot
+     integer :: i, j, m, k, kr
+     real(ATMOSPHERE_KIND_)    :: rrg, sigtop, sigbot
+     real(ATMOSPHERE_KIND_), dimension(isc:iec,jsc:jec) :: tref
+     real(ATMOSPHERE_KIND_), parameter :: tlaps = 6.5e-3
+
+     rrg  = _DBL_(_RL_(rdgas / grav))
+
+     do j=jsc,jec
+        do i=isc,iec
+           p_surf(i,j) = _DBL_(_RL_(Atm(mygrid)%ps(i,j)))
+           t_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,npz)))
+           p_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%delp(i,j,npz)/(Atm(mygrid)%peln(i,npz+1,j)-Atm(mygrid)%peln(i,npz,j))))
+           z_bot(i,j) = rrg*t_bot(i,j)*_DBL_(_RL_((1.+zvir*Atm(mygrid)%q(i,j,npz,sphum)))) *  &
+                        _DBL_(_RL_((1. - Atm(mygrid)%pe(i,npz,j)/p_bot(i,j))))
+        enddo
+     enddo
+
+     if ( present(slp) ) then
+       ! determine 0.8 sigma reference level
+       sigtop = _DBL_(_RL_(Atm(mygrid)%ak(1)/pstd_mks+Atm(mygrid)%bk(1)))
+       do k = 1, npz
+          sigbot = _DBL_(_RL_(Atm(mygrid)%ak(k+1)/pstd_mks+Atm(mygrid)%bk(k+1)))
+          if (sigbot+sigtop > 1.6) then
+             kr = k
+             exit
+          endif
+          sigtop = sigbot
+       enddo
+       do j=jsc,jec
+          do i=isc,iec
+             ! sea level pressure
+             tref(i,j) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,kr) * (Atm(mygrid)%delp(i,j,kr)/ &
+                              ((Atm(mygrid)%peln(i,kr+1,j)-Atm(mygrid)%peln(i,kr,j))*Atm(mygrid)%ps(i,j)))**(-rrg*tlaps)))
+             slp(i,j) = _DBL_(_RL_(Atm(mygrid)%ps(i,j)*(1.+tlaps*Atm(mygrid)%phis(i,j)/(real(tref(i,j))*grav))**(1./(rrg*tlaps))))
+          enddo
+       enddo
+     endif
+
+  ! Copy tracers
+     do m=1,nq
+        do j=jsc,jec
+           do i=isc,iec
+              tr_bot(i,j,m) = _DBL_(_RL_(Atm(mygrid)%q(i,j,npz,m)))
+           enddo
+        enddo
+     enddo
+
+   end subroutine GET_BOTTOM_MASS_
+
+   subroutine GET_BOTTOM_WIND_ ( u_bot, v_bot )
+!-----------------------------------------------------------
+! returns u and v on the mass grid at the lowest model level
+!-----------------------------------------------------------
+   real(ATMOSPHERE_KIND_), intent(out), dimension(isc:iec,jsc:jec):: u_bot, v_bot
+   integer i, j
+
+   do j=jsc,jec
+      do i=isc,iec
+         u_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%u_srf(i,j)))
+         v_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%v_srf(i,j)))
+      enddo
+   enddo
+
+ end subroutine GET_BOTTOM_WIND_
+
+ subroutine GET_STOCK_PE_(index, value)
+   integer, intent(in) :: index
+   real(ATMOSPHERE_KIND_),   intent(out) :: value
+
+#ifdef USE_STOCK
+   include 'stock.inc'
+#endif
+
+   real(ATMOSPHERE_KIND_) wm(isc:iec,jsc:jec)
+   integer i,j,k
+
+   select case (index)
+
+#ifdef USE_STOCK
+   case (ISTOCK_WATER)
+#else
+   case (1)
+#endif
+
+!----------------------
+! Perform vertical sum:
+!----------------------
+     wm = 0.
+     do j=jsc,jec
+        do k=1,npz
+           do i=isc,iec
+! Warning: the following works only with AM2 physics: water vapor; cloud water, cloud ice.
+              wm(i,j) = wm(i,j) + _DBL_(_RL_(Atm(mygrid)%delp(i,j,k) * ( Atm(mygrid)%q(i,j,k,sphum)   +  &
+                                                              Atm(mygrid)%q(i,j,k,liq_wat) +  &
+                                                              Atm(mygrid)%q(i,j,k,ice_wat) )))
+           enddo
+        enddo
+     enddo
+
+!----------------------
+! Horizontal sum:
+!----------------------
+     value = 0.
+     do j=jsc,jec
+        do i=isc,iec
+           value = value + wm(i,j)*_DBL_(_RL_(Atm(mygrid)%gridstruct%area(i,j)))
+        enddo
+     enddo
+     value = value/_DBL_(_RL_(grav))
+
+   case default
+     value = 0.0
+   end select
+
+ end subroutine GET_STOCK_PE_

--- a/driver/SHiELDFULL/include/atmosphere_r4.fh
+++ b/driver/SHiELDFULL/include/atmosphere_r4.fh
@@ -1,0 +1,22 @@
+#undef ATMOSPHERE_KIND_
+#define ATMOSPHERE_KIND_ r4_kind
+
+#undef ATMOSPHERE_GRID_BDRY_
+#define ATMOSPHERE_GRID_BDRY_ atmosphere_grid_bdry_r4
+
+#undef ATMOSPHERE_PREF_
+#define ATMOSPHERE_PREF_ atmosphere_pref_r4
+
+#undef ATMOSPHERE_CELL_AREA_
+#define ATMOSPHERE_CELL_AREA_ atmosphere_cell_area_r4
+
+#undef GET_BOTTOM_MASS_
+#define GET_BOTTOM_MASS_ get_bottom_mass_r4
+
+#undef GET_BOTTOM_WIND_
+#define GET_BOTTOM_WIND_ get_bottom_wind_r4
+
+#undef GET_STOCK_PE_
+#define GET_STOCK_PE_ get_stock_pe_r4
+
+#include "atmosphere.inc"

--- a/driver/SHiELDFULL/include/atmosphere_r8.fh
+++ b/driver/SHiELDFULL/include/atmosphere_r8.fh
@@ -1,0 +1,22 @@
+#undef ATMOSPHERE_KIND_
+#define ATMOSPHERE_KIND_ r8_kind
+
+#undef ATMOSPHERE_GRID_BDRY_
+#define ATMOSPHERE_GRID_BDRY_ atmosphere_grid_bdry_r8
+
+#undef ATMOSPHERE_PREF_
+#define ATMOSPHERE_PREF_ atmosphere_pref_r8
+
+#undef ATMOSPHERE_CELL_AREA_
+#define ATMOSPHERE_CELL_AREA_ atmosphere_cell_area_r8
+
+#undef GET_BOTTOM_MASS_
+#define GET_BOTTOM_MASS_ get_bottom_mass_r8
+
+#undef GET_BOTTOM_WIND_
+#define GET_BOTTOM_WIND_ get_bottom_wind_r8
+
+#undef GET_STOCK_PE_
+#define GET_STOCK_PE_ get_stock_pe_r8
+
+#include "atmosphere.inc"

--- a/model/boundary.F90
+++ b/model/boundary.F90
@@ -22,7 +22,11 @@
 module boundary_mod
 
   use fv_mp_mod,         only: is_master
-  use constants_mod,     only: grav
+#ifdef OVERLOAD_R4
+    use constantsR4_mod, only: grav
+#else
+    use constants_mod, only: grav
+#endif
 
   use mpp_domains_mod,    only: mpp_get_compute_domain, mpp_get_data_domain, mpp_get_global_domain
   use mpp_domains_mod,    only: CENTER, CORNER, NORTH, EAST

--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -21,7 +21,11 @@
 
 module dyn_core_mod
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,    only: rdgas, cp_air, pi
+#else
   use constants_mod,      only: rdgas, cp_air, pi
+#endif
   use fv_arrays_mod,      only: radius ! scaled for small earth
   use mpp_mod,            only: mpp_pe
   use mpp_domains_mod,    only: CGRID_NE, DGRID_NE, mpp_get_boundary, mpp_update_domains,  &

--- a/model/fast_phys.F90
+++ b/model/fast_phys.F90
@@ -27,7 +27,11 @@
 
 module fast_phys_mod
 
+#ifdef OVERLOAD_R4
+    use constantsR4_mod, only: rdgas, grav
+#else
     use constants_mod, only: rdgas, grav
+#endif
     use fv_grid_utils_mod, only: cubed_to_latlon, update_dwinds_phys
     use fv_arrays_mod, only: fv_grid_type, fv_grid_bounds_type
     use mpp_domains_mod, only: domain2d, mpp_update_domains

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -29,7 +29,11 @@ module fv_arrays_mod
   use horiz_interp_type_mod, only: horiz_interp_type
   use mpp_mod,               only: mpp_broadcast
   use platform_mod,          only: r8_kind
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,       only: cnst_radius => radius, cnst_omega => omega
+#else
   use constants_mod,         only: cnst_radius => radius, cnst_omega => omega
+#endif
   public
 
   integer, public, parameter :: R_GRID = r8_kind

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -26,7 +26,11 @@
 
 module fv_control_mod
 
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,     only: pi=>pi_8, kappa, grav, rdgas
+#else
    use constants_mod,       only: pi=>pi_8, kappa, grav, rdgas
+#endif
    use fv_arrays_mod,       only: radius ! scaled for small earth
    use field_manager_mod,   only: MODEL_ATMOS
    use fms_mod,             only: write_version_number, check_nml_error

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -20,7 +20,11 @@
 !***********************************************************************
 
 module fv_dynamics_mod
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,     only: grav, pi=>pi_8, hlv, rdgas, rvgas, cp_vapor
+#else
    use constants_mod,       only: grav, pi=>pi_8, hlv, rdgas, rvgas, cp_vapor
+#endif
    use fv_arrays_mod,       only: radius, omega ! scaled for small earth
    use dyn_core_mod,        only: dyn_core, del2_cubed, init_ijk_mem
    use fv_mapz_mod,         only: compute_total_energy, Lagrangian_to_Eulerian, moist_cv, moist_cp

--- a/model/fv_grid_utils.F90
+++ b/model/fv_grid_utils.F90
@@ -22,7 +22,11 @@
  module fv_grid_utils_mod
 
 #include <fms_platform.h>
+#ifdef OVERLOAD_R4
+ use constantsR4_mod, only: pi=>pi_8
+#else
  use constants_mod,   only: pi=>pi_8
+#endif
  use fv_arrays_mod,   only: radius, omega ! scaled for small earth
  use mpp_mod,         only: FATAL, mpp_error, WARNING
  use external_sst_mod, only: i_sst, j_sst, sst_ncep, sst_anom

--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -26,7 +26,11 @@
 ! Revise the OpenMP code to avoid crash
 module fv_mapz_mod
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,   only: pi=>pi_8, rvgas, rdgas, grav, hlv, hlf, cp_air, cp_vapor
+#else
   use constants_mod,     only: pi=>pi_8, rvgas, rdgas, grav, hlv, hlf, cp_air, cp_vapor
+#endif
   use fv_arrays_mod,     only: radius ! scaled for small earth
   use tracer_manager_mod,only: get_tracer_index, adjust_mass
   use field_manager_mod, only: MODEL_ATMOS

--- a/model/fv_nesting.F90
+++ b/model/fv_nesting.F90
@@ -37,7 +37,11 @@ module fv_nesting_mod
    use fv_arrays_mod,       only: allocate_fv_nest_BC_type, fv_atmos_type, fv_grid_bounds_type, deallocate_fv_nest_BC_type
    use fv_grid_utils_mod,   only: ptop_min, g_sum, cubed_to_latlon, f_p
    use init_hydro_mod,      only: p_var
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,     only: grav, pi=>pi_8, hlv, rdgas, cp_air, rvgas, cp_vapor, kappa
+#else
    use constants_mod,       only: grav, pi=>pi_8, hlv, rdgas, cp_air, rvgas, cp_vapor, kappa
+#endif
    use fv_arrays_mod,       only: radius ! scaled for small earth
    use fv_mapz_mod,         only: mappm
    use fv_timing_mod,       only: timing_on, timing_off

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -47,8 +47,13 @@ module fv_regional_mod
    use time_manager_mod,  only: get_time                                &
                                ,operator(-),operator(/)                 &
                                ,time_type,time_type_to_real
-   use constants_mod,     only: cp_air, cp_vapor, grav, kappa           &
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,  only: cp_air, cp_vapor, grav, kappa           &
                                ,pi=>pi_8,rdgas, rvgas
+#else
+  use constants_mod,     only: cp_air, cp_vapor, grav, kappa           &
+                              ,pi=>pi_8,rdgas, rvgas
+#endif
    use fv_arrays_mod,     only: fv_atmos_type                           &
                                ,fv_grid_bounds_type                     &
                                ,fv_regional_bc_bounds_type              &

--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -24,7 +24,11 @@ module fv_sg_mod
 !-----------------------------------------------------------------------
 ! FV sub-grid mixing
 !-----------------------------------------------------------------------
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,    only: rdgas, rvgas, cp_air, cp_vapor, hlv, hlf, kappa, grav
+#else
   use constants_mod,      only: rdgas, rvgas, cp_air, cp_vapor, hlv, hlf, kappa, grav
+#endif
   use tracer_manager_mod, only: get_tracer_index
   use field_manager_mod,  only: MODEL_ATMOS
   use gfdl_mp_mod,        only: wqs, mqs3d, c_liq, c_ice

--- a/model/fv_update_phys.F90
+++ b/model/fv_update_phys.F90
@@ -21,7 +21,11 @@
 
 module fv_update_phys_mod
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,    only: kappa, rdgas, rvgas, grav, cp_air, cp_vapor, pi=>pi_8, TFREEZE, wtmair, wtmh2o
+#else
   use constants_mod,      only: kappa, rdgas, rvgas, grav, cp_air, cp_vapor, pi=>pi_8, TFREEZE, wtmair, wtmh2o
+#endif
   use field_manager_mod,  only: MODEL_ATMOS
   use mpp_domains_mod,    only: mpp_update_domains, domain2d
   use mpp_parameter_mod,  only: AGRID_PARAM=>AGRID

--- a/model/intermediate_phys.F90
+++ b/model/intermediate_phys.F90
@@ -27,7 +27,11 @@
 
 module intermediate_phys_mod
 
+#ifdef OVERLOAD_R4
+    use constantsR4_mod, only: rdgas, grav
+#else
     use constants_mod, only: rdgas, grav
+#endif
     use fv_grid_utils_mod, only: cubed_to_latlon, update_dwinds_phys
     use fv_arrays_mod, only: fv_grid_type, fv_grid_bounds_type, inline_mp_type
     use mpp_domains_mod, only: domain2d, mpp_update_domains

--- a/model/nh_core.F90
+++ b/model/nh_core.F90
@@ -24,7 +24,11 @@ module nh_core_mod
 ! To do list:
 ! include moisture effect in pt
 !------------------------------
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,   only: rdgas, cp_air, grav
+#else
    use constants_mod,     only: rdgas, cp_air, grav
+#endif
    use tp_core_mod,       only: fv_tp_2d
    use nh_utils_mod,      only: update_dz_c, update_dz_d, nh_bc
    use nh_utils_mod,      only: sim_solver, sim1_solver, sim3_solver

--- a/model/nh_utils.F90
+++ b/model/nh_utils.F90
@@ -24,7 +24,11 @@ module nh_utils_mod
 ! To do list:
 ! include moisture effect in pt
 !------------------------------
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,     only: rdgas, cp_air, grav, pi_8
+#else
    use constants_mod,     only: rdgas, cp_air, grav, pi_8
+#endif
    use tp_core_mod,       only: fv_tp_2d
    use sw_core_mod,       only: fill_4corners, del6_vt_flux
    use fv_arrays_mod,     only: fv_grid_bounds_type, fv_grid_type, fv_nest_BC_type_3d

--- a/tools/coarse_grained_diagnostics.F90
+++ b/tools/coarse_grained_diagnostics.F90
@@ -21,7 +21,11 @@
 
 module coarse_grained_diagnostics_mod
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod, only: rdgas, grav, pi=>pi_8
+#else
   use constants_mod, only: rdgas, grav, pi=>pi_8
+#endif
   use diag_manager_mod, only: diag_axis_init, register_diag_field, register_static_field, send_data
   use field_manager_mod,  only: MODEL_ATMOS
   use fv_arrays_mod, only: fv_atmos_type, fv_coarse_graining_type

--- a/tools/coarse_grained_restart_files.F90
+++ b/tools/coarse_grained_restart_files.F90
@@ -26,7 +26,11 @@ module coarse_grained_restart_files_mod
        weighted_block_edge_average_x, weighted_block_edge_average_y, &
        mask_area_weights, block_upsample, remap_edges_along_x, &
        remap_edges_along_y, vertically_remap_field
+#ifdef OVERLOAD_R4
+  use constantsR4_mod, only: GRAV, RDGAS, RVGAS
+#else
   use constants_mod, only: GRAV, RDGAS, RVGAS
+#endif
   use field_manager_mod, only: MODEL_ATMOS
   use fms2_io_mod,      only: register_restart_field, write_restart, open_file, close_file, register_variable_attribute, variable_exists
   use fv_arrays_mod, only: coarse_restart_type, fv_atmos_type

--- a/tools/external_aero.F90
+++ b/tools/external_aero.F90
@@ -171,7 +171,12 @@ end subroutine load_aero
 
 subroutine read_aero(is, ie, js, je, npz, nq, Time, pe, peln, qa, kord_tr, fill)
 
-	use constants_mod, only: grav
+#ifdef OVERLOAD_R4
+	use constantsR4_mod, only: grav
+#else
+  use constants_mod, only: grav
+#endif
+
 	use diag_manager_mod, only: send_data
 	use time_manager_mod, only: get_date, set_date, get_time, operator(-)
 	use tracer_manager_mod, only: get_tracer_index

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -42,7 +42,11 @@ module external_ic_mod
    use tracer_manager_mod, only: set_tracer_profile
    use field_manager_mod,  only: MODEL_ATMOS
 
+#ifdef OVERLOAD_R4
+   use constantsR4_mod,   only: pi=>pi_8, grav, kappa, rdgas, rvgas, cp_air
+#else
    use constants_mod,     only: pi=>pi_8, grav, kappa, rdgas, rvgas, cp_air
+#endif
    use fv_arrays_mod,     only: omega ! scaled for small earth
    use fv_arrays_mod,     only: fv_atmos_type, fv_grid_type, fv_grid_bounds_type, R_GRID
    use fv_diagnostics_mod,only: prt_maxmin, prt_mxm, prt_gb_nh_sh, prt_height

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -24,8 +24,13 @@
 
 module fv_diagnostics_mod
 
+#ifdef OVERLOAD_R4
+ use constantsR4_mod,    only: grav, rdgas, rvgas, pi=>pi_8, kappa, WTMAIR, WTMCO2, WTMH2O, &
+                               hlv, cp_air, cp_vapor, TFREEZE
+#else
  use constants_mod,      only: grav, rdgas, rvgas, pi=>pi_8, kappa, WTMAIR, WTMCO2, WTMH2O, &
                                hlv, cp_air, cp_vapor, TFREEZE
+#endif
  use fv_arrays_mod,      only: radius ! scaled for small earth
  use fms_mod,            only: write_version_number
  use time_manager_mod,   only: time_type, get_date, get_time

--- a/tools/fv_eta.F90
+++ b/tools/fv_eta.F90
@@ -20,7 +20,11 @@
 !***********************************************************************
 
 module fv_eta_mod
+#ifdef OVERLOAD_R4
+ use constantsR4_mod,only: kappa, grav, cp_air, rdgas
+#else
  use constants_mod,  only: kappa, grav, cp_air, rdgas
+#endif
  use fv_mp_mod,      only: is_master
  use fms_mod,        only: FATAL, error_mesg
  use fms2_io_mod,    only: ascii_read

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -21,7 +21,11 @@
 
 module fv_grid_tools_mod
 
-  use constants_mod,  only: grav, pi=>pi_8
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,  only: grav, pi=>pi_8
+#else
+  use constants_mod,only: grav, pi=>pi_8
+#endif
   use fv_arrays_mod,  only: radius, omega ! scaled for small earth
 !  use test_cases_mod, only: small_earth_scale
   use fv_arrays_mod, only: fv_atmos_type, fv_grid_type, fv_grid_bounds_type, R_GRID

--- a/tools/fv_iau_mod.F90
+++ b/tools/fv_iau_mod.F90
@@ -41,7 +41,11 @@ module fv_iau_mod
   use mpp_mod,             only: mpp_error, FATAL, NOTE, mpp_pe
   use mpp_domains_mod,     only: domain2d
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,     only: pi=>pi_8
+#else
   use constants_mod,       only: pi=>pi_8
+#endif
   use fv_arrays_mod,       only: fv_atmos_type,       &
                                  fv_grid_type,        &
                                  fv_grid_bounds_type, &

--- a/tools/fv_nggps_diag.F90
+++ b/tools/fv_nggps_diag.F90
@@ -63,7 +63,11 @@ module fv_nggps_diags_mod
 ! </table>
 
  use mpp_mod,            only: mpp_pe, mpp_root_pe,FATAL,mpp_error
+#ifdef OVERLOAD_R4
+ use constantsR4_mod,      only: grav, rdgas
+#else
  use constants_mod,      only: grav, rdgas
+#endif
  use time_manager_mod,   only: time_type, get_time
  use diag_manager_mod,   only: register_diag_field, send_data
  use diag_axis_mod,      only: get_axis_global_length, get_diag_axis, get_diag_axis_name

--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -28,7 +28,11 @@ module fv_nwp_nudge_mod
 
  use external_sst_mod,  only: i_sst, j_sst, sst_ncep, sst_anom, forecast_mode
  use diag_manager_mod,  only: register_diag_field, send_data
+#ifdef OVERLOAD_R4
+ use constantsR4_mod,     only: pi=>pi_8, grav, rdgas, RAD_TO_DEG, cp_air, kappa, cnst_radius =>radius
+#else
  use constants_mod,     only: pi=>pi_8, grav, rdgas, RAD_TO_DEG, cp_air, kappa, cnst_radius =>radius
+#endif
  use fms_mod,           only: write_version_number, check_nml_error
  use fms2_io_mod,       only: file_exists
  use mpp_mod,           only: mpp_error, FATAL, stdlog, get_unit, mpp_pe, input_nml_file

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -30,7 +30,11 @@ module fv_restart_mod
   ! for the model.
   !</DESCRIPTION>
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,     only: kappa, pi=>pi_8, rdgas, grav, rvgas, cp_air
+#else
   use constants_mod,       only: kappa, pi=>pi_8, rdgas, grav, rvgas, cp_air
+#endif
   use fv_arrays_mod,       only: radius, omega ! scaled for small earth
   use fv_arrays_mod,       only: fv_atmos_type, fv_nest_type, fv_grid_bounds_type, R_GRID
   use fv_io_mod,           only: fv_io_init, fv_io_read_restart, fv_io_write_restart, &

--- a/tools/fv_surf_map.F90
+++ b/tools/fv_surf_map.F90
@@ -26,7 +26,12 @@
       use fms2_io_mod,       only: file_exists
       use mpp_mod,           only: get_unit, input_nml_file, mpp_error
       use mpp_domains_mod,   only: mpp_update_domains, domain2d
+#ifdef OVERLOAD_R4
+      use constantsR4_mod,   only: grav, pi=>pi_8
+#else
       use constants_mod,     only: grav, pi=>pi_8
+#endif
+
 
       use fv_grid_utils_mod, only: great_circle_dist, latlon2xyz, v_prod, normalize_vect
       use fv_grid_utils_mod, only: g_sum, global_mx, vect_cross

--- a/tools/fv_treat_da_inc.F90
+++ b/tools/fv_treat_da_inc.F90
@@ -47,8 +47,13 @@ module fv_treat_da_inc_mod
                                get_tracer_index
   use field_manager_mod, only: MODEL_ATMOS
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,   only: pi=>pi_8, grav, kappa, &
+                               rdgas, rvgas, cp_air
+#else
   use constants_mod,     only: pi=>pi_8, grav, kappa, &
                                rdgas, rvgas, cp_air
+#endif
   use fv_arrays_mod,     only: omega ! scaled for small earth
   use fv_arrays_mod,     only: fv_atmos_type, &
                                fv_grid_type, &

--- a/tools/init_hydro.F90
+++ b/tools/init_hydro.F90
@@ -21,7 +21,11 @@
 
 module init_hydro_mod
 
+#ifdef OVERLOAD_R4
+      use constantsR4_mod,      only: grav, rdgas, rvgas
+#else
       use constants_mod,      only: grav, rdgas, rvgas
+#endif
       use fv_grid_utils_mod,  only: g_sum
       use fv_mp_mod,          only: is_master
       use field_manager_mod,  only: MODEL_ATMOS

--- a/tools/test_cases.F90
+++ b/tools/test_cases.F90
@@ -21,7 +21,11 @@
 
  module test_cases_mod
 
+#ifdef OVERLOAD_R4
+      use constantsR4_mod,   only: cnst_radius=>radius, pi=>pi_8, cnst_omega=>omega, grav, kappa, rdgas, cp_air, rvgas
+#else
       use constants_mod,     only: cnst_radius=>radius, pi=>pi_8, cnst_omega=>omega, grav, kappa, rdgas, cp_air, rvgas
+#endif
       use fv_arrays_mod,     only: radius, omega ! scaled for small earth
       use init_hydro_mod,    only: p_var, hydro_eq, hydro_eq_ext
       use fv_mp_mod,         only: is_master,        &


### PR DESCRIPTION
Allows a mixed precision compilation of the dycore. FV3 can be compiled in 32bit and works with other components compiled in 64bit. This depends on:
https://github.com/NOAA-GFDL/SHiELD_physics/pull/56
https://github.com/NOAA-GFDL/SHiELD_build/pull/46

Inspired from https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/357
