### PR TITLE
fix conditional L1863

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -1860,7 +1860,7 @@ contains
 
        if ( id_vort200>0 .or. id_vort500>0 .or. id_vort850>0 .or. id_vorts>0   &
             .or. id_vort>0 .or. id_pv>0 .or. id_pv350k>0 .or. id_pv550k>0 &
-            .or. id_rh>0 .or. id_x850>0 .or. id_uh03>0 .or. id_uh25>0 &
+            .or. id_srh>0 .or. id_x850>0 .or. id_uh03>0 .or. id_uh25>0 &
             .or. id_srh1 > 0 .or. id_srh3 > 0 .or. id_srh25 > 0 &
             .or. id_ustm > 0 .or. id_vstm > 0) then
           call get_vorticity(isc, iec, jsc, jec, isd, ied, jsd, jed, npz, Atm(n)%u, Atm(n)%v, wk, &


### PR DESCRIPTION
**Description**

The conditional to calculate vorticity-related diagnostics, including storm relative helicity SRH, resolves to "TRUE" if the relative humidity diagnostic is active. It's a one character typo: id_rh .neq. id_srh

Fixes # N/A I just noticed this when searching the code for id_rh

**How Has This Been Tested?**

It's a one character typo. Conceivably, some previous runs with some combinations of diag table variables will produce correct output (e.g., the case where only id_srh was true and no other vorticity diagnostics were requested will now work) or an unnecessary vorticity calculation is avoided (id_rh was true and no vorticity diagnostics requested).

**Checklist:**

Please check all whether they apply or not
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published in downstream modules
