### PR TITLE
FMS2_IO: correcting restart reads in remap_restarts

### DIFF
--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -283,13 +283,13 @@ contains
        zsize = (/size(Atm%u,3)/)
        call fv_io_register_axis(Atm%Fv_restart_tile, numx=numx_2d, numy=numy_2d, xpos=xpos_2d, ypos=ypos_2d, numz=numz, zsize=zsize)
 
-       !--- optionally include D-grid winds even if restarting from A-grid winds
        if (Atm%flagstruct%is_ideal_case) then
           call register_restart_field(Atm%Fv_restart_tile, 'u0', Atm%u0, &
                dim_names_4d, is_optional=.true.)
           call register_restart_field(Atm%Fv_restart_tile, 'v0', Atm%v0, &
                dim_names_4d2, is_optional=.true.)
        endif
+       !--- optionally include D-grid winds even if restarting from A-grid winds
        if (Atm%flagstruct%write_optional_dgrid_vel_rst .and. Atm%flagstruct%restart_from_agrid_winds) then
           call register_restart_field(Atm%Fv_restart_tile, 'u', Atm%u, &
                dim_names_4d, is_optional=.true.)
@@ -737,10 +737,6 @@ contains
        stile_name = ''
     endif
 
-!!!! A NOTE about file names
-!!! file_exist() needs the full relative path, including INPUT/
-!!! But register_restart_field ONLY looks in INPUT/ and so JUST needs the file name!!
-
        fname = 'INPUT/fv_core.res'//trim(stile_name)//'.nc'
        if (open_file(Fv_tile_restart_r, fname, "read", fv_domain, is_restart=.true.)) then
           call fv_io_register_axis(Fv_tile_restart_r, numx=2, numy=2, xpos=xpos_2d, ypos=ypos_2d, numz=2, &
@@ -749,8 +745,8 @@ contains
              call register_restart_field (Fv_tile_restart_r, 'u0', u0_r, dim_names_4d_u, is_optional=.true.)
              call register_restart_field (Fv_tile_restart_r, 'v0', v0_r, dim_names_4d_v, is_optional=.true.)
           endif
-          call register_restart_field (Fv_tile_restart_r, 'u', u_r, dim_names_4d_u, is_optional=.true.)
-          call register_restart_field (Fv_tile_restart_r, 'v', v_r, dim_names_4d_v, is_optional=.true.)
+          call register_restart_field (Fv_tile_restart_r, 'u', u_r, dim_names_4d_u)
+          call register_restart_field (Fv_tile_restart_r, 'v', v_r, dim_names_4d_v)
           if (.not.Atm(1)%flagstruct%hydrostatic) then
              call register_restart_field (Fv_tile_restart_r, 'W', w_r, dim_names_4d_w, is_optional=.true.)
              call register_restart_field (Fv_tile_restart_r, 'DZ', delz_r, dim_names_4d_w, is_optional=.true.)
@@ -758,9 +754,9 @@ contains
                 call register_restart_field (Fv_tile_restart_r, 'ZE0', ze0_r, dim_names_4d_ze0, is_optional=.true.)
              endif
           endif
-          call register_restart_field (Fv_tile_restart_r, 'T', pt_r, dim_names_4d_w, is_optional=.true.)
-          call register_restart_field (Fv_tile_restart_r, 'delp', delp_r, dim_names_4d_w, is_optional=.true.)
-          call register_restart_field (Fv_tile_restart_r, 'phis', Atm(1)%phis, dim_names_3d_phis, is_optional=.true.)
+          call register_restart_field (Fv_tile_restart_r, 'T', pt_r, dim_names_4d_w)
+          call register_restart_field (Fv_tile_restart_r, 'delp', delp_r, dim_names_4d_w)
+          call register_restart_field (Fv_tile_restart_r, 'phis', Atm(1)%phis, dim_names_3d_phis)
           call read_restart(Fv_tile_restart_r, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
           call close_file(FV_tile_restart_r)
        endif

--- a/tools/fv_io.F90
+++ b/tools/fv_io.F90
@@ -68,7 +68,7 @@ module fv_io_mod
   private
 
   public :: fv_io_init, fv_io_exit, fv_io_read_restart, remap_restart, fv_io_write_restart
-  public :: fv_io_read_tracers, fv_io_register_restart, fv_io_register_nudge_restart
+  public :: fv_io_read_tracers, fv_io_register_nudge_restart
   public :: fv_io_register_restart_BCs
   public :: fv_io_write_BCs, fv_io_read_BCs
   public :: fv_io_register_axis
@@ -635,6 +635,13 @@ contains
     type(FmsNetcdfDomainFile_t) :: FV_tile_restart_r, Tra_restart_r
     type(FmsNetcdfFile_t)       :: Fv_restart_r
     integer, allocatable, dimension(:) :: pes !< Array of the pes in the current pelist
+    character(len=8), dimension(2)  :: dim_names_2d_ak !< Dimension names used to register restart fields
+    character(len=8), dimension(3)  :: dim_names_3d_phis !< Dimension names used to register restart fields
+    character(len=8), dimension(4)  :: dim_names_4d_u, dim_names_4d_v, dim_names_4d_w, dim_names_4d_ze0 !< Dimension
+                                       !! names used to register restart fields
+    integer, dimension(1) :: xpos, ypos !< x/y position for registering axis
+    integer, dimension(2) :: xpos_2d, ypos_2d !< 2-dim x/y position for registering axis
+    integer, dimension(2) :: zsize_2d !< 2-dim z axis size for registering axis
 
 !
 !-------------------------------------------------------------------------
@@ -685,12 +692,39 @@ contains
            allocate ( ze0_r(isc:iec, jsc:jec,  npz_rst+1) )
     endif
 
+    dim_names_2d_ak(1) = "xaxis_1"
+    dim_names_2d_ak(2) = "Time"
+    dim_names_3d_phis(1) = "xaxis_1"
+    dim_names_3d_phis(2) = "yaxis_2"
+    dim_names_3d_phis(3) = "Time"
+    dim_names_4d_u(1) = "xaxis_1"
+    dim_names_4d_u(2) = "yaxis_1"
+    dim_names_4d_u(3) = "zaxis_1"
+    dim_names_4d_u(4) = "Time"
+    dim_names_4d_v = dim_names_4d_u
+    dim_names_4d_v(1) = "xaxis_2"
+    dim_names_4d_v(2) = "yaxis_2"
+    dim_names_4d_w = dim_names_4d_u
+    dim_names_4d_w(2) = "yaxis_2"
+    dim_names_4d_ze0 = dim_names_4d_u
+    dim_names_4d_ze0(2) = "yaxis_2"
+    dim_names_4d_ze0(3) = "zaxis_2"
+    xpos = (/CENTER/)
+    ypos = (/CENTER/)
+    xpos_2d = (/CENTER, EAST/)
+    ypos_2d = (/NORTH, CENTER/)
+    zsize_2d(1) = npz_rst
+    zsize_2d(2) = npz_rst+1
+
     fname = 'INPUT/fv_core.res.nc'
     allocate(pes(mpp_npes()))
     call mpp_get_current_pelist(pes)
     if (open_file(Fv_restart_r,fname,"read", is_restart=.true., pelist=pes)) then
-       call read_data(Fv_restart_r, 'ak', ak_r(:))
-       call read_data(Fv_restart_r, 'bk', bk_r(:))
+       call register_axis(Fv_restart_r, "xaxis_1", size(ak_r(:), 1))
+       call register_axis(Fv_restart_r, "Time", unlimited)
+       call register_restart_field (Fv_restart_r, 'ak', ak_r(:), dim_names_2d_ak)
+       call register_restart_field (Fv_restart_r, 'bk', bk_r(:), dim_names_2d_ak)
+       call read_restart(Fv_restart_r)
        call close_file(Fv_restart_r)
     endif
     deallocate(pes)
@@ -709,22 +743,25 @@ contains
 
        fname = 'INPUT/fv_core.res'//trim(stile_name)//'.nc'
        if (open_file(Fv_tile_restart_r, fname, "read", fv_domain, is_restart=.true.)) then
+          call fv_io_register_axis(Fv_tile_restart_r, numx=2, numy=2, xpos=xpos_2d, ypos=ypos_2d, numz=2, &
+               zsize=zsize_2d)
           if (Atm(1)%flagstruct%is_ideal_case) then
-             call read_data(Fv_tile_restart_r, 'u0', u0_r)
-             call read_data(Fv_tile_restart_r, 'v0', v0_r)
+             call register_restart_field (Fv_tile_restart_r, 'u0', u0_r, dim_names_4d_u, is_optional=.true.)
+             call register_restart_field (Fv_tile_restart_r, 'v0', v0_r, dim_names_4d_v, is_optional=.true.)
           endif
-          call read_data(Fv_tile_restart_r, 'u', u_r)
-          call read_data(Fv_tile_restart_r, 'v', v_r)
+          call register_restart_field (Fv_tile_restart_r, 'u', u_r, dim_names_4d_u, is_optional=.true.)
+          call register_restart_field (Fv_tile_restart_r, 'v', v_r, dim_names_4d_v, is_optional=.true.)
           if (.not.Atm(1)%flagstruct%hydrostatic) then
-             call read_data(Fv_tile_restart_r, 'W', w_r)
-             call read_data(Fv_tile_restart_r, 'DZ', delz_r)
+             call register_restart_field (Fv_tile_restart_r, 'W', w_r, dim_names_4d_w, is_optional=.true.)
+             call register_restart_field (Fv_tile_restart_r, 'DZ', delz_r, dim_names_4d_w, is_optional=.true.)
              if ( Atm(1)%flagstruct%hybrid_z ) then
-                call read_data(Fv_tile_restart_r, 'ZE0', ze0_r)
+                call register_restart_field (Fv_tile_restart_r, 'ZE0', ze0_r, dim_names_4d_ze0, is_optional=.true.)
              endif
           endif
-          call read_data(Fv_tile_restart_r, 'T', pt_r)
-          call read_data(Fv_tile_restart_r, 'delp', delp_r)
-          call read_data(Fv_tile_restart_r, 'phis', Atm(1)%phis)
+          call register_restart_field (Fv_tile_restart_r, 'T', pt_r, dim_names_4d_w, is_optional=.true.)
+          call register_restart_field (Fv_tile_restart_r, 'delp', delp_r, dim_names_4d_w, is_optional=.true.)
+          call register_restart_field (Fv_tile_restart_r, 'phis', Atm(1)%phis, dim_names_3d_phis, is_optional=.true.)
+          call read_restart(Fv_tile_restart_r, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
           call close_file(FV_tile_restart_r)
        endif
 
@@ -746,7 +783,8 @@ contains
          fname = 'INPUT/mg_drag.res'//trim(stile_name)//'.nc'
          Atm(1)%Mg_restart_is_open = open_file(Atm(1)%Mg_restart, fname, "read", fv_domain, is_restart=.true.)
          if (Atm(1)%Mg_restart_is_open) then
-            call read_data(Atm(1)%Mg_restart, 'ghprime', Atm(1)%sgh)
+            call fv_io_register_restart(Atm(1))
+            call read_restart(Atm(1)%Mg_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
             call close_file(Atm(1)%Mg_restart)
             Atm(1)%Mg_restart_is_open = .false.
          else
@@ -756,7 +794,8 @@ contains
          fname = 'INPUT/fv_land.res'//trim(stile_name)//'.nc'
          Atm(1)%Lnd_restart_is_open = open_file(Atm(1)%Lnd_restart, fname, "read", fv_domain, is_restart=.true.)
          if (Atm(1)%Lnd_restart_is_open) then
-           call read_data(Atm(1)%Lnd_restart, 'oro', Atm(1)%oro)
+           call fv_io_register_restart(Atm(1))
+           call read_restart(Atm(1)%Lnd_restart, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
            call close_file(Atm(1)%Lnd_restart)
            Atm(1)%Lnd_restart_is_open = .false.
          else
@@ -766,20 +805,18 @@ contains
 
        fname = 'INPUT/fv_tracer.res'//trim(stile_name)//'.nc'
        if (open_file(Tra_restart_r, fname, "read", fv_domain, is_restart=.true.)) then
+         call fv_io_register_axis(Tra_restart_r, numx=1, numy=1, xpos=xpos, ypos=ypos, numz=1, zsize=(/npz_rst/))
          do nt = 1, ntprog
             call get_tracer_names(MODEL_ATMOS, nt, tracer_name)
-            call set_tracer_profile (MODEL_ATMOS, nt, q_r(isc:iec,jsc:jec,:,nt)  )
-            if (variable_exists(Tra_restart_r, tracer_name)) then
-               call read_data(Tra_restart_r, tracer_name, q_r(:,:,:,nt))
-            endif
+           call register_restart_field(Tra_restart_r, tracer_name, q_r(:,:,:,nt), &
+                dim_names_4d_u, is_optional=.true.)
          enddo
          do nt = ntprog+1, ntracers
             call get_tracer_names(MODEL_ATMOS, nt, tracer_name)
-            call set_tracer_profile (MODEL_ATMOS, nt, qdiag_r(isc:iec,jsc:jec,:,nt)  )
-            if (variable_exists(Tra_restart_r, tracer_name)) then
-               call read_data (Tra_restart_r, tracer_name, qdiag_r(:,:,:,nt))
-            endif
+            call register_restart_field(Tra_restart_r, tracer_name, qdiag_r(:,:,:,nt), &
+                 dim_names_4d_u, is_optional=.true.)
          enddo
+         call read_restart(Tra_restart_r, ignore_checksum=Atm(1)%flagstruct%ignore_rst_cksum)
          call close_file(Tra_restart_r)
        else
          call mpp_error(NOTE,'==> Warning from remap_restart: Expected file '//trim(fname)//' does not exist')

--- a/tools/fv_restart.F90
+++ b/tools/fv_restart.F90
@@ -253,10 +253,6 @@ contains
        !This call still appears to be necessary to get isd, etc. correct
        !call switch_current_Atm(Atm(n)) !TODO should NOT be necessary now that we manually set isd, etc.
 
-       !--- call fv_io_register_restart to register restart field to be written out in fv_io_write_restart
-       !if (n==this_grid) call fv_io_register_restart(Atm(n)%domain,Atm(n:n))
-       !if (Atm(n)%neststruct%nested) call fv_io_register_restart_BCs(Atm(n)) !TODO put into fv_io_register_restart
-
        if (n==this_grid) then
 
           !3. External_ic


### PR DESCRIPTION
**Description**

The reading of restarts in the fv_io.F90 `remap_restarts` subroutine was mistakenly using read_data (fms2_io) rather than read_restart (fms2_io).  This led to the issues seen in issue #204.  This PR corrects this issue.

Fixes #204 

**How Has This Been Tested?**

Tested on Gaea with regression tests

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
