### PR TITLE
n_con fix

### DIFF
--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -293,7 +293,7 @@ contains
 
     call init_ijk_mem(isd, ied, jsd, jed, npz, heat_source, 0.)
 
-    if ( flagstruct%convert_ke .or. flagstruct%vtdm4> 1.E-4 ) then
+    if ( flagstruct%convert_ke .or. (flagstruct%do_vort_damp .and. flagstruct%vtdm4> 1.E-4) ) then
          n_con = npz
     else
          if ( flagstruct%d2_bg_k1 < 1.E-3 ) then


### PR DESCRIPTION
This is a bug fix we just made in the Gitlab version of FV3. The fix here ensures n_con is set to npz only when vorticity damping is truly used (do_vort_damp is true and vtdm4 is large enough).

REF:
https://gitlab.gfdl.noaa.gov/fv3team/atmos_cubed_sphere/-/merge_requests/175