### PR TITLE
GNU SHiELDFULL Fix

### DIFF
--- a/driver/SHiELDFULL/atmosphere.F90
+++ b/driver/SHiELDFULL/atmosphere.F90
@@ -196,11 +196,9 @@ character(len=20)   :: mod_name = 'SHiELD/atmosphere_mod'
 contains
 
 #if defined(OVERLOAD_R4)
-#define _DBL_(X) DBLE(X)
-#define _RL_(X) REAL(X,KIND=4)
+#define _DBL_ DBLE
 #else
-#define _DBL_(X) X
-#define _RL_(X) X
+#define _DBL_ 
 #endif
 
 
@@ -1623,13 +1621,6 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
 
 
 
-#if defined(OVERLOAD_R4)
-#define _DBL_(X) DBLE(X)
-#define _RL_(X) REAL(X,KIND=4)
-#else
-#define _DBL_(X) X
-#define _RL_(X) X
-#endif
  subroutine atmos_phys_driver_statein (IPD_Data, Atm_block)
    type (IPD_data_type),      intent(inout) :: IPD_Data(:)
    type (block_control_type), intent(in)    :: Atm_block
@@ -1647,7 +1638,7 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
 !!! - "Layer" means "layer mean", ie. the average value in a layer
 !!! - "Level" means "level interface", ie the point values at the top or bottom of a layer
 
-   ptop =  _DBL_(_RL_(Atm(mygrid)%ak(1)))
+   ptop =  _DBL_(Atm(mygrid)%ak(1))
    pktop  = (ptop/p00)**kappa
    pk0inv = (1.0_kind_phys/p00)**kappa
 
@@ -1684,19 +1675,19 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
          do ix = 1, blen
            i = Atm_block%index(nb)%ii(ix)
            j = Atm_block%index(nb)%jj(ix)
-           IPD_Data(nb)%Statein%prew(ix) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prew(i,j)))
-           IPD_Data(nb)%Statein%prer(ix) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prer(i,j)))
-           IPD_Data(nb)%Statein%prei(ix) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prei(i,j)))
-           IPD_Data(nb)%Statein%pres(ix) = _DBL_(_RL_(Atm(mygrid)%inline_mp%pres(i,j)))
-           IPD_Data(nb)%Statein%preg(ix) = _DBL_(_RL_(Atm(mygrid)%inline_mp%preg(i,j)))
+           IPD_Data(nb)%Statein%prew(ix) = _DBL_(Atm(mygrid)%inline_mp%prew(i,j))
+           IPD_Data(nb)%Statein%prer(ix) = _DBL_(Atm(mygrid)%inline_mp%prer(i,j))
+           IPD_Data(nb)%Statein%prei(ix) = _DBL_(Atm(mygrid)%inline_mp%prei(i,j))
+           IPD_Data(nb)%Statein%pres(ix) = _DBL_(Atm(mygrid)%inline_mp%pres(i,j))
+           IPD_Data(nb)%Statein%preg(ix) = _DBL_(Atm(mygrid)%inline_mp%preg(i,j))
            if (Atm(mygrid)%flagstruct%do_cosp) then
              do k = 1, npz
                k1 = npz+1-k ! flipping the index
-               IPD_Data(nb)%Statein%prefluxw(ix,k) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prefluxw(i,j,k1)))
-               IPD_Data(nb)%Statein%prefluxr(ix,k) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prefluxr(i,j,k1)))
-               IPD_Data(nb)%Statein%prefluxi(ix,k) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prefluxi(i,j,k1)))
-               IPD_Data(nb)%Statein%prefluxs(ix,k) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prefluxs(i,j,k1)))
-               IPD_Data(nb)%Statein%prefluxg(ix,k) = _DBL_(_RL_(Atm(mygrid)%inline_mp%prefluxg(i,j,k1)))
+               IPD_Data(nb)%Statein%prefluxw(ix,k) = _DBL_(Atm(mygrid)%inline_mp%prefluxw(i,j,k1))
+               IPD_Data(nb)%Statein%prefluxr(ix,k) = _DBL_(Atm(mygrid)%inline_mp%prefluxr(i,j,k1))
+               IPD_Data(nb)%Statein%prefluxi(ix,k) = _DBL_(Atm(mygrid)%inline_mp%prefluxi(i,j,k1))
+               IPD_Data(nb)%Statein%prefluxs(ix,k) = _DBL_(Atm(mygrid)%inline_mp%prefluxs(i,j,k1))
+               IPD_Data(nb)%Statein%prefluxg(ix,k) = _DBL_(Atm(mygrid)%inline_mp%prefluxg(i,j,k1))
              enddo
            endif
          enddo
@@ -1710,26 +1701,26 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
             !Indices for FV's vertical coordinate, for which 1 = top
             !here, k is the index for GFS's vertical coordinate, for which 1 = bottom
          k1 = npz+1-k ! flipping the index
-         IPD_Data(nb)%Statein%tgrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,k1)))
-         IPD_Data(nb)%Statein%ugrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%ua(i,j,k1)))
-         IPD_Data(nb)%Statein%vgrs(ix,k) = _DBL_(_RL_(Atm(mygrid)%va(i,j,k1)))
-          IPD_Data(nb)%Statein%vvl(ix,k) = _DBL_(_RL_(omega_for_physics(i,j,k1)))
-         IPD_Data(nb)%Statein%prsl(ix,k) = _DBL_(_RL_(Atm(mygrid)%delp(i,j,k1)))   ! Total mass
-         if (Atm(mygrid)%flagstruct%do_diss_est)IPD_Data(nb)%Statein%diss_est(ix,k) = _DBL_(_RL_(Atm(mygrid)%diss_est(i,j,k1)))
+         IPD_Data(nb)%Statein%tgrs(ix,k) = _DBL_(Atm(mygrid)%pt(i,j,k1))
+         IPD_Data(nb)%Statein%ugrs(ix,k) = _DBL_(Atm(mygrid)%ua(i,j,k1))
+         IPD_Data(nb)%Statein%vgrs(ix,k) = _DBL_(Atm(mygrid)%va(i,j,k1))
+          IPD_Data(nb)%Statein%vvl(ix,k) = _DBL_(omega_for_physics(i,j,k1))
+         IPD_Data(nb)%Statein%prsl(ix,k) = _DBL_(Atm(mygrid)%delp(i,j,k1))   ! Total mass
+         if (Atm(mygrid)%flagstruct%do_diss_est)IPD_Data(nb)%Statein%diss_est(ix,k) = _DBL_(Atm(mygrid)%diss_est(i,j,k1))
 
          if (.not.Atm(mygrid)%flagstruct%hydrostatic .and. (.not.Atm(mygrid)%flagstruct%use_hydro_pressure))  &
-           IPD_Data(nb)%Statein%phii(ix,k+1) = IPD_Data(nb)%Statein%phii(ix,k) - _DBL_(_RL_(Atm(mygrid)%delz(i,j,k1)*grav))
+           IPD_Data(nb)%Statein%phii(ix,k+1) = IPD_Data(nb)%Statein%phii(ix,k) - _DBL_(Atm(mygrid)%delz(i,j,k1)*grav)
 
 ! Convert to tracer mass:
-         IPD_Data(nb)%Statein%qgrs(ix,k,1:nq_adv) =  _DBL_(_RL_(Atm(mygrid)%q(i,j,k1,1:nq_adv))) &
+         IPD_Data(nb)%Statein%qgrs(ix,k,1:nq_adv) =  _DBL_(Atm(mygrid)%q(i,j,k1,1:nq_adv)) &
                                                           * IPD_Data(nb)%Statein%prsl(ix,k)
 
          if (dnats .gt. 0) &
-             IPD_Data(nb)%Statein%qgrs(ix,k,nq_adv+1:nq) =  _DBL_(_RL_(Atm(mygrid)%q(i,j,k1,nq_adv+1:nq)))
+             IPD_Data(nb)%Statein%qgrs(ix,k,nq_adv+1:nq) =  _DBL_(Atm(mygrid)%q(i,j,k1,nq_adv+1:nq))
          !--- SHOULD THESE BE CONVERTED TO MASS SINCE THE DYCORE DOES NOT TOUCH THEM IN ANY WAY???
          !--- See Note in state update...
          if ( ncnst > nq) &
-             IPD_Data(nb)%Statein%qgrs(ix,k,nq+1:ncnst) = _DBL_(_RL_(Atm(mygrid)%qdiag(i,j,k1,nq+1:ncnst)))
+             IPD_Data(nb)%Statein%qgrs(ix,k,nq+1:ncnst) = _DBL_(Atm(mygrid)%qdiag(i,j,k1,nq+1:ncnst))
 ! Remove the contribution of condensates to delp (mass):
          if ( Atm(mygrid)%flagstruct%nwat .eq. 6 ) then
             IPD_Data(nb)%Statein%prsl(ix,k) = IPD_Data(nb)%Statein%prsl(ix,k) &

--- a/driver/SHiELDFULL/include/atmosphere.inc
+++ b/driver/SHiELDFULL/include/atmosphere.inc
@@ -33,14 +33,14 @@
  subroutine ATMOSPHERE_PREF_ (p_ref)
    real(ATMOSPHERE_KIND_), dimension(:,:), intent(inout) :: p_ref
 
-   p_ref = _DBL_(_RL_(pref))
+   p_ref = _DBL_(pref)
 
  end subroutine ATMOSPHERE_PREF_
 
   subroutine ATMOSPHERE_CELL_AREA_  (area_out)
    real(ATMOSPHERE_KIND_), dimension(:,:),  intent(out)          :: area_out
 
-   area_out(1:iec-isc+1, 1:jec-jsc+1) =  _DBL_(_RL_(Atm(mygrid)%gridstruct%area (isc:iec,jsc:jec)))
+   area_out(1:iec-isc+1, 1:jec-jsc+1) =  _DBL_(Atm(mygrid)%gridstruct%area (isc:iec,jsc:jec))
 
  end subroutine ATMOSPHERE_CELL_AREA_
 
@@ -57,23 +57,23 @@
      real(ATMOSPHERE_KIND_), dimension(isc:iec,jsc:jec) :: tref
      real(ATMOSPHERE_KIND_), parameter :: tlaps = 6.5e-3
 
-     rrg  = _DBL_(_RL_(rdgas / grav))
+     rrg  = _DBL_(rdgas / grav)
 
      do j=jsc,jec
         do i=isc,iec
-           p_surf(i,j) = _DBL_(_RL_(Atm(mygrid)%ps(i,j)))
-           t_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,npz)))
-           p_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%delp(i,j,npz)/(Atm(mygrid)%peln(i,npz+1,j)-Atm(mygrid)%peln(i,npz,j))))
-           z_bot(i,j) = rrg*t_bot(i,j)*_DBL_(_RL_((1.+zvir*Atm(mygrid)%q(i,j,npz,sphum)))) *  &
-                        _DBL_(_RL_((1. - Atm(mygrid)%pe(i,npz,j)/p_bot(i,j))))
+           p_surf(i,j) = _DBL_(Atm(mygrid)%ps(i,j))
+           t_bot(i,j) = _DBL_(Atm(mygrid)%pt(i,j,npz))
+           p_bot(i,j) = _DBL_(Atm(mygrid)%delp(i,j,npz)/(Atm(mygrid)%peln(i,npz+1,j)-Atm(mygrid)%peln(i,npz,j)))
+           z_bot(i,j) = rrg*t_bot(i,j)*_DBL_((1.+zvir*Atm(mygrid)%q(i,j,npz,sphum))) *  &
+                        _DBL_((1. - Atm(mygrid)%pe(i,npz,j)/p_bot(i,j)))
         enddo
      enddo
 
      if ( present(slp) ) then
        ! determine 0.8 sigma reference level
-       sigtop = _DBL_(_RL_(Atm(mygrid)%ak(1)/pstd_mks+Atm(mygrid)%bk(1)))
+       sigtop = _DBL_(Atm(mygrid)%ak(1)/pstd_mks+Atm(mygrid)%bk(1))
        do k = 1, npz
-          sigbot = _DBL_(_RL_(Atm(mygrid)%ak(k+1)/pstd_mks+Atm(mygrid)%bk(k+1)))
+          sigbot = _DBL_(Atm(mygrid)%ak(k+1)/pstd_mks+Atm(mygrid)%bk(k+1))
           if (sigbot+sigtop > 1.6) then
              kr = k
              exit
@@ -83,9 +83,9 @@
        do j=jsc,jec
           do i=isc,iec
              ! sea level pressure
-             tref(i,j) = _DBL_(_RL_(Atm(mygrid)%pt(i,j,kr) * (Atm(mygrid)%delp(i,j,kr)/ &
-                              ((Atm(mygrid)%peln(i,kr+1,j)-Atm(mygrid)%peln(i,kr,j))*Atm(mygrid)%ps(i,j)))**(-rrg*tlaps)))
-             slp(i,j) = _DBL_(_RL_(Atm(mygrid)%ps(i,j)*(1.+tlaps*Atm(mygrid)%phis(i,j)/(real(tref(i,j))*grav))**(1./(rrg*tlaps))))
+             tref(i,j) = _DBL_(Atm(mygrid)%pt(i,j,kr) * (Atm(mygrid)%delp(i,j,kr)/ &
+                              ((Atm(mygrid)%peln(i,kr+1,j)-Atm(mygrid)%peln(i,kr,j))*Atm(mygrid)%ps(i,j)))**(-rrg*tlaps))
+             slp(i,j) = _DBL_(Atm(mygrid)%ps(i,j)*(1.+tlaps*Atm(mygrid)%phis(i,j)/(real(tref(i,j))*grav))**(1./(rrg*tlaps)))
           enddo
        enddo
      endif
@@ -94,7 +94,7 @@
      do m=1,nq
         do j=jsc,jec
            do i=isc,iec
-              tr_bot(i,j,m) = _DBL_(_RL_(Atm(mygrid)%q(i,j,npz,m)))
+              tr_bot(i,j,m) = _DBL_(Atm(mygrid)%q(i,j,npz,m))
            enddo
         enddo
      enddo
@@ -110,8 +110,8 @@
 
    do j=jsc,jec
       do i=isc,iec
-         u_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%u_srf(i,j)))
-         v_bot(i,j) = _DBL_(_RL_(Atm(mygrid)%v_srf(i,j)))
+         u_bot(i,j) = _DBL_(Atm(mygrid)%u_srf(i,j))
+         v_bot(i,j) = _DBL_(Atm(mygrid)%v_srf(i,j))
       enddo
    enddo
 
@@ -144,9 +144,9 @@
         do k=1,npz
            do i=isc,iec
 ! Warning: the following works only with AM2 physics: water vapor; cloud water, cloud ice.
-              wm(i,j) = wm(i,j) + _DBL_(_RL_(Atm(mygrid)%delp(i,j,k) * ( Atm(mygrid)%q(i,j,k,sphum)   +  &
+              wm(i,j) = wm(i,j) + _DBL_(Atm(mygrid)%delp(i,j,k) * ( Atm(mygrid)%q(i,j,k,sphum)   +  &
                                                               Atm(mygrid)%q(i,j,k,liq_wat) +  &
-                                                              Atm(mygrid)%q(i,j,k,ice_wat) )))
+                                                              Atm(mygrid)%q(i,j,k,ice_wat) ))
            enddo
         enddo
      enddo
@@ -157,10 +157,10 @@
      value = 0.
      do j=jsc,jec
         do i=isc,iec
-           value = value + wm(i,j)*_DBL_(_RL_(Atm(mygrid)%gridstruct%area(i,j)))
+           value = value + wm(i,j)*_DBL_(Atm(mygrid)%gridstruct%area(i,j))
         enddo
      enddo
-     value = value/_DBL_(_RL_(grav))
+     value = value/_DBL_(grav)
 
    case default
      value = 0.0


### PR DESCRIPTION
**Description**

shieldfull was not building with the GNU compiler due to the cpp functions defined in atmosphere.F90.  When I change them from functions to just macros, gnu can now compile.  The `_RL_` function can be removed entirely.

Fixes # (issue)

**How Has This Been Tested?**

Tested on Gaea with SHiELD_build

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
