### PR TITLE
Add a new parameter to control cutoff level for implicit RF

### DIFF
--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -633,7 +633,7 @@ contains
                                ptop, phis, omga, ptc,  &
                                q_con,  delpc, gz,  pkc, ws3, flagstruct%p_fac, &
                                flagstruct%a_imp, flagstruct%scale_z, pfull, &
-                               flagstruct%fast_tau_w_sec, flagstruct%rf_cutoff_fast )
+                               flagstruct%fast_tau_w_sec, flagstruct%rf_cutoff_w )
                                                call timing_off('Riem_Solver')
 
            if (gridstruct%nested) then

--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -633,7 +633,7 @@ contains
                                ptop, phis, omga, ptc,  &
                                q_con,  delpc, gz,  pkc, ws3, flagstruct%p_fac, &
                                flagstruct%a_imp, flagstruct%scale_z, pfull, &
-                               flagstruct%fast_tau_w_sec, flagstruct%rf_cutoff )
+                               flagstruct%fast_tau_w_sec, flagstruct%rf_cutoff_fast )
                                                call timing_off('Riem_Solver')
 
            if (gridstruct%nested) then

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -698,6 +698,8 @@ module fv_arrays_mod
                          !< considered; and for non-hydrostatic models values of 10 or less should be
                          !< considered, with smaller values for higher-resolution.
    real    :: rf_cutoff = 30.E2   !< Pressure below which no Rayleigh damping is applied if tau > 0.
+   real    :: rf_cutoff_fast = 30.E2   !< Pressure below which no fast vertical velocity Rayleigh
+                                       ! damping is applied if fast_tau_w_sec > 0.
    real    :: fast_tau_w_sec = 0.0 !< Time scale (seconds) for Rayleigh damping applied to vertical velocity only.
                                    !< Values of 0.2 are very effective at eliminating spurious vertical motion in
                                    !< the stratosphere. Default is 0.0, which disables this.

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -698,7 +698,7 @@ module fv_arrays_mod
                          !< considered; and for non-hydrostatic models values of 10 or less should be
                          !< considered, with smaller values for higher-resolution.
    real    :: rf_cutoff = 30.E2   !< Pressure below which no Rayleigh damping is applied if tau > 0.
-   real    :: rf_cutoff_fast = 1.E2   !< Pressure below which no fast vertical velocity Rayleigh
+   real    :: rf_cutoff_w = 1.E2  !< Pressure below which no fast vertical velocity Rayleigh
                                        ! damping is applied if fast_tau_w_sec > 0.
    real    :: fast_tau_w_sec = 0.0 !< Time scale (seconds) for Rayleigh damping applied to vertical velocity only.
                                    !< Values of 0.2 are very effective at eliminating spurious vertical motion in

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -698,7 +698,7 @@ module fv_arrays_mod
                          !< considered; and for non-hydrostatic models values of 10 or less should be
                          !< considered, with smaller values for higher-resolution.
    real    :: rf_cutoff = 30.E2   !< Pressure below which no Rayleigh damping is applied if tau > 0.
-   real    :: rf_cutoff_fast = 30.E2   !< Pressure below which no fast vertical velocity Rayleigh
+   real    :: rf_cutoff_fast = 1.E2   !< Pressure below which no fast vertical velocity Rayleigh
                                        ! damping is applied if fast_tau_w_sec > 0.
    real    :: fast_tau_w_sec = 0.0 !< Time scale (seconds) for Rayleigh damping applied to vertical velocity only.
                                    !< Values of 0.2 are very effective at eliminating spurious vertical motion in

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -333,6 +333,7 @@ module fv_control_mod
      real    , pointer :: tau_w
      real    , pointer :: fast_tau_w_sec
      real    , pointer :: rf_cutoff
+     real    , pointer :: rf_cutoff_fast
      logical , pointer :: filter_phys
      logical , pointer :: dwind_2d
      logical , pointer :: breed_vortex_inline
@@ -912,6 +913,7 @@ module fv_control_mod
        tau_w                         => Atm%flagstruct%tau_w
        fast_tau_w_sec                => Atm%flagstruct%fast_tau_w_sec
        rf_cutoff                     => Atm%flagstruct%rf_cutoff
+       rf_cutoff_fast                => Atm%flagstruct%rf_cutoff_fast
        filter_phys                   => Atm%flagstruct%filter_phys
        dwind_2d                      => Atm%flagstruct%dwind_2d
        breed_vortex_inline           => Atm%flagstruct%breed_vortex_inline
@@ -1080,7 +1082,7 @@ module fv_control_mod
             dry_mass, grid_type, do_Held_Suarez, do_reed_physics, reed_cond_only, &
             consv_te, fill, filter_phys, fill_dp, fill_wz, fill_gfs, consv_am, RF_fast, &
             range_warn, dwind_2d, inline_q, z_tracer, reproduce_sum, adiabatic, do_vort_damp, no_dycore,   &
-            tau, tau_w, fast_tau_w_sec, tau_h2o, rf_cutoff, nf_omega, hydrostatic, fv_sg_adj, sg_cutoff, breed_vortex_inline,  &
+            tau, tau_w, fast_tau_w_sec, tau_h2o, rf_cutoff, rf_cutoff_fast, nf_omega, hydrostatic, fv_sg_adj, sg_cutoff, breed_vortex_inline,  &
             na_init, nudge_dz, hybrid_z, Make_NH, n_zs_filter, nord_zs_filter, full_zs_filter, reset_eta,         &
             pnats, dnats, dnrts, a2b_ord, remap_t, p_ref, d2_bg_k1, d2_bg_k2,  &
             c2l_ord, dx_const, dy_const, umax, deglat,      &

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -333,7 +333,7 @@ module fv_control_mod
      real    , pointer :: tau_w
      real    , pointer :: fast_tau_w_sec
      real    , pointer :: rf_cutoff
-     real    , pointer :: rf_cutoff_fast
+     real    , pointer :: rf_cutoff_w
      logical , pointer :: filter_phys
      logical , pointer :: dwind_2d
      logical , pointer :: breed_vortex_inline
@@ -913,7 +913,7 @@ module fv_control_mod
        tau_w                         => Atm%flagstruct%tau_w
        fast_tau_w_sec                => Atm%flagstruct%fast_tau_w_sec
        rf_cutoff                     => Atm%flagstruct%rf_cutoff
-       rf_cutoff_fast                => Atm%flagstruct%rf_cutoff_fast
+       rf_cutoff_w                => Atm%flagstruct%rf_cutoff_w
        filter_phys                   => Atm%flagstruct%filter_phys
        dwind_2d                      => Atm%flagstruct%dwind_2d
        breed_vortex_inline           => Atm%flagstruct%breed_vortex_inline
@@ -1082,7 +1082,7 @@ module fv_control_mod
             dry_mass, grid_type, do_Held_Suarez, do_reed_physics, reed_cond_only, &
             consv_te, fill, filter_phys, fill_dp, fill_wz, fill_gfs, consv_am, RF_fast, &
             range_warn, dwind_2d, inline_q, z_tracer, reproduce_sum, adiabatic, do_vort_damp, no_dycore,   &
-            tau, tau_w, fast_tau_w_sec, tau_h2o, rf_cutoff, rf_cutoff_fast, nf_omega, hydrostatic, fv_sg_adj, sg_cutoff, breed_vortex_inline,  &
+            tau, tau_w, fast_tau_w_sec, tau_h2o, rf_cutoff, rf_cutoff_w, nf_omega, hydrostatic, fv_sg_adj, sg_cutoff, breed_vortex_inline,  &
             na_init, nudge_dz, hybrid_z, Make_NH, n_zs_filter, nord_zs_filter, full_zs_filter, reset_eta,         &
             pnats, dnats, dnrts, a2b_ord, remap_t, p_ref, d2_bg_k1, d2_bg_k2,  &
             c2l_ord, dx_const, dy_const, umax, deglat,      &

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -913,7 +913,7 @@ module fv_control_mod
        tau_w                         => Atm%flagstruct%tau_w
        fast_tau_w_sec                => Atm%flagstruct%fast_tau_w_sec
        rf_cutoff                     => Atm%flagstruct%rf_cutoff
-       rf_cutoff_w                => Atm%flagstruct%rf_cutoff_w
+       rf_cutoff_w                   => Atm%flagstruct%rf_cutoff_w
        filter_phys                   => Atm%flagstruct%filter_phys
        dwind_2d                      => Atm%flagstruct%dwind_2d
        breed_vortex_inline           => Atm%flagstruct%breed_vortex_inline

--- a/model/nh_utils.F90
+++ b/model/nh_utils.F90
@@ -353,11 +353,11 @@ CONTAINS
 #endif
                            ptop, hs, w3,  pt, q_con, &
                            delp, gz,  pef,  ws, p_fac, a_imp, scale_m, &
-                           pfull, fast_tau_w_sec, rf_cutoff)
+                           pfull, fast_tau_w_sec, rf_cutoff_fast)
 
    integer, intent(in):: is, ie, js, je, ng, km
    integer, intent(in):: ms
-   real, intent(in):: dt,  akap, cp, ptop, p_fac, a_imp, scale_m, fast_tau_w_sec, rf_cutoff
+   real, intent(in):: dt,  akap, cp, ptop, p_fac, a_imp, scale_m, fast_tau_w_sec, rf_cutoff_fast
    real, intent(in):: ws(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt, delp
    real, intent(in), dimension(is-ng:,js-ng:,1:):: q_con, cappa
@@ -392,10 +392,10 @@ CONTAINS
       allocate(rff(km))
       RFw_initialized = .true.
       do k=1,km
-         if (pfull(k) > rf_cutoff) exit
+         if (pfull(k) > rf_cutoff_fast) exit
          k_rf = k
          rff_temp = real(dt/fast_tau_w_sec,kind=8) &
-                  * sin(0.5d0*pi_8*log(real(rf_cutoff/pfull(k),kind=8))/log(real(rf_cutoff/ptop, kind=8)))**2
+                  * sin(0.5d0*pi_8*log(real(rf_cutoff_fast/pfull(k),kind=8))/log(real(rf_cutoff_fast/ptop, kind=8)))**2
          rff(k) = 1.0d0 / ( 1.0d0+rff_temp )
       enddo
    endif

--- a/model/nh_utils.F90
+++ b/model/nh_utils.F90
@@ -353,11 +353,11 @@ CONTAINS
 #endif
                            ptop, hs, w3,  pt, q_con, &
                            delp, gz,  pef,  ws, p_fac, a_imp, scale_m, &
-                           pfull, fast_tau_w_sec, rf_cutoff_fast)
+                           pfull, fast_tau_w_sec, rf_cutoff_w)
 
    integer, intent(in):: is, ie, js, je, ng, km
    integer, intent(in):: ms
-   real, intent(in):: dt,  akap, cp, ptop, p_fac, a_imp, scale_m, fast_tau_w_sec, rf_cutoff_fast
+   real, intent(in):: dt,  akap, cp, ptop, p_fac, a_imp, scale_m, fast_tau_w_sec, rf_cutoff_w
    real, intent(in):: ws(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt, delp
    real, intent(in), dimension(is-ng:,js-ng:,1:):: q_con, cappa
@@ -392,10 +392,10 @@ CONTAINS
       allocate(rff(km))
       RFw_initialized = .true.
       do k=1,km
-         if (pfull(k) > rf_cutoff_fast) exit
+         if (pfull(k) > rf_cutoff_w) exit
          k_rf = k
          rff_temp = real(dt/fast_tau_w_sec,kind=8) &
-                  * sin(0.5d0*pi_8*log(real(rf_cutoff_fast/pfull(k),kind=8))/log(real(rf_cutoff_fast/ptop, kind=8)))**2
+                  * sin(0.5d0*pi_8*log(real(rf_cutoff_w/pfull(k),kind=8))/log(real(rf_cutoff_w/ptop, kind=8)))**2
          rff(k) = 1.0d0 / ( 1.0d0+rff_temp )
       enddo
    endif

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -355,8 +355,8 @@ contains
     trange = (/    5.,  350. /)  ! temperature
     trange_bad = (/   130.,  350. /)  ! temperature
 #else
-    trange = (/  100.,  350. /)  ! temperature
-    trange_bad = (/  150.,  350. /)  ! temperature
+    trange = (/  50.,  350. /)  ! temperature
+    trange_bad = (/  50.,  350. /)  ! temperature
 #endif
     endif
     rhrange = (/  -10.,  150. /)  ! RH


### PR DESCRIPTION
**Description**

 A new parameter rf_cutoff_fast is introduced to independently control the cutoff level for implicit Rayleigh damping when fast_tau_w_sec>0, decoupling it from the cutoff level (rf_cutoff) used for explicit damping.



**How Has This Been Tested?**

It is tested on HERA with intel compiler

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
