### PR TITLE
Changes in the FV3 dycore to support 3DTKE EDMF PBL physic scheme

### DIFF
--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -182,6 +182,8 @@ use DYCORE_typedefs,        only: DYCORE_data_type
 #ifdef GFS_TYPES
 use GFS_typedefs,           only: IPD_control_type => GFS_control_type, kind_phys
 use GFS_typedefs,           only: GFS_statein_type, GFS_stateout_type, GFS_sfcprop_type
+! SA-3D-TKE (Samuel)
+use GFS_typedefs,           only: GFS_tbd_type
 #else
 use IPD_typedefs,           only: IPD_data_type, IPD_control_type, kind_phys => IPD_kind_phys
 #endif
@@ -693,11 +695,17 @@ contains
 !                     Atm(n)%flagstruct%n_split, Atm(n)%flagstruct%q_split,     &
                       Atm(n)%u,    Atm(n)%v,     Atm(n)%w,  Atm(n)%delz,        &
                       Atm(n)%flagstruct%hydrostatic,                            &
+!The following variable is used for SA-3D-TKE
+                      Atm(n)%flagstruct%sa3dtke_dyco,                           &
                       Atm(n)%pt  , Atm(n)%delp,  Atm(n)%q,  Atm(n)%ps,          &
                       Atm(n)%pe,   Atm(n)%pk,    Atm(n)%peln,                   &
                       Atm(n)%pkz,  Atm(n)%phis,  Atm(n)%q_con,                  &
                       Atm(n)%omga, Atm(n)%ua,    Atm(n)%va, Atm(n)%uc,          &
-                      Atm(n)%vc,   Atm(n)%ak,    Atm(n)%bk, Atm(n)%mfx,         &
+                      Atm(n)%vc,                                                &
+!The following three variables are used for SA-3D-TKE
+                      Atm(n)%deform_1,Atm(n)%deform_2,                          &
+                      Atm(n)%deform_3,Atm(n)%dku3d_h,Atm(n)%dku3d_e,            &
+                      Atm(n)%ak,    Atm(n)%bk, Atm(n)%mfx,                      &
                       Atm(n)%mfy , Atm(n)%cx,    Atm(n)%cy, Atm(n)%ze0,         &
                       Atm(n)%flagstruct%hybrid_z,                               &
                       Atm(n)%gridstruct,  Atm(n)%flagstruct,                    &
@@ -1894,9 +1902,14 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq,  n_split_loc,                                       &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
+!The following variable is used for SA-3D-TKE
+                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
+!The following three variables are used for SA-3D-TKE
+                     Atm(mygrid)%deform_1,Atm(mygrid)%deform_2,                   &
+                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e,  &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -1909,9 +1922,14 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq, n_split_loc,                                        &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
+!The following variable is used for SA-3D-TKE
+                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
+!The following three variables are used for SA-3D-TKE
+                     Atm(mygrid)%deform_1, Atm(mygrid)%deform_2,          &
+                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e, &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -1985,9 +2003,14 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq, Atm(mygrid)%flagstruct%n_split,        &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
+!The following variable is used for SA-3D-TKE
+                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
+!The following three variables are used for SA-3D-TKE
+                     Atm(mygrid)%deform_1,Atm(mygrid)%deform_2,       &
+                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e,  &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -1999,9 +2022,14 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq, Atm(mygrid)%flagstruct%n_split,        &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
+!The following variable is used for SA-3D-TKE
+                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
+!The following three variables are used for SA-3D-TKE
+                     Atm(mygrid)%deform_1,Atm(mygrid)%deform_2,       &
+                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e,  &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -2064,6 +2092,7 @@ contains
 !>@detail Performs a mass adjustment to be consistent with the
 !! GFS physics and if necessary, converts quantities to hydrostatic
 !! representation.
+!! SA-3D-TKE (added IPD_Tbd in the input) (kyf)
 #if defined(OVERLOAD_R4)
 #define _DBL_(X) DBLE(X)
 #define _RL_(X) REAL(X,KIND=4)
@@ -2071,9 +2100,11 @@ contains
 #define _DBL_(X) X
 #define _RL_(X) X
 #endif
- subroutine atmos_phys_driver_statein (IPD_Control, IPD_Statein, Atm_block,flip_vc)
+ subroutine atmos_phys_driver_statein (IPD_Control, IPD_Statein, IPD_Tbd, Atm_block,flip_vc)
    type (IPD_control_type),   intent(in)    :: IPD_Control
    type (GFS_statein_type),   intent(inout) :: IPD_Statein
+   ! SA-3D-TKE (added IPD_Tbd) (kyf)
+   type (GFS_tbd_type),       intent(inout) :: IPD_Tbd
    type (block_control_type), intent(in)    :: Atm_block
    logical,                   intent(in)    :: flip_vc
 !--------------------------------------
@@ -2113,8 +2144,10 @@ contains
 !---------------------------------------------------------------------
 ! use most up to date atmospheric properties when running serially
 !---------------------------------------------------------------------
+! SA-3D-TKE added IPD_Tbd (kyf)
 !$OMP parallel do default (none) &
 !$OMP             shared  (Atm_block, Atm, IPD_Control, IPD_Statein, npz, nq, ncnst, sphum, liq_wat, &
+!$OMP                      IPD_Tbd, &
 !$OMP                      ice_wat, rainwat, snowwat, graupel, pk0inv, ptop,   &
 !$OMP                      pktop, zvir, mygrid, dnats, nq_adv, flip_vc) &
 #ifdef MULTI_GASES
@@ -2130,6 +2163,27 @@ contains
 ! log(pe) <-- prsik
 
      blen = Atm_block%blksz(nb)
+!The following is for SA-3D-TKE
+       if(Atm(mygrid)%flagstruct%sa3dtke_dyco) then
+!The following is for SA-3D-TKE (pass dku to dyn_core)
+        do k = 1, npz
+          kz = npz+1-k
+          if(flip_vc) then
+            k1 = kz ! flipping the index
+          else
+            k1 = k
+          endif
+          do ix = 1, blen
+            i = Atm_block%index(nb)%ii(ix)
+            j = Atm_block%index(nb)%jj(ix)
+            ! SA-3D-TKE (added im) (kyf)
+            im = IPD_control%chunk_begin(nb)+ix-1
+            ! SA-3D-TKE (modified IPD_Tbd and ix into im) (kyf)
+            Atm(mygrid)%dku3d_h(i,j,k) = IPD_Tbd%dku3d_h(im,k1)
+            Atm(mygrid)%dku3d_e(i,j,k) = IPD_Tbd%dku3d_e(im,k1)
+          enddo
+        enddo
+       endif
 
      do k = 1, npz
        !Indices for FV's vertical coordinate, for which 1 = top
@@ -2154,6 +2208,13 @@ contains
          endif
          IPD_Statein%vvl(im,k) = _DBL_(_RL_(Atm(mygrid)%omga(i,j,k1)))
          IPD_Statein%prsl(im,k) = _DBL_(_RL_(Atm(mygrid)%delp(i,j,k1)))   ! Total mass
+!The following is for SA-3D-TKE
+         if(Atm(mygrid)%flagstruct%sa3dtke_dyco) then
+          IPD_Statein%def_1(ix,k) = _DBL_(_RL_(Atm(mygrid)%deform_1(i,j,k1)))
+          IPD_Statein%def_2(ix,k) = _DBL_(_RL_(Atm(mygrid)%deform_2(i,j,k1)))
+          IPD_Statein%def_3(ix,k) = _DBL_(_RL_(Atm(mygrid)%deform_3(i,j,k1)))
+         endif
+
          if (Atm(mygrid)%flagstruct%do_skeb) IPD_Statein%diss_est(im,k) = _DBL_(_RL_(Atm(mygrid)%diss_est(i,j,k1)))
 
          if(flip_vc) then

--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -182,7 +182,7 @@ use DYCORE_typedefs,        only: DYCORE_data_type
 #ifdef GFS_TYPES
 use GFS_typedefs,           only: IPD_control_type => GFS_control_type, kind_phys
 use GFS_typedefs,           only: GFS_statein_type, GFS_stateout_type, GFS_sfcprop_type
-! SA-3D-TKE (Samuel)
+! SA-3D-TKE (kyf)
 use GFS_typedefs,           only: GFS_tbd_type
 #else
 use IPD_typedefs,           only: IPD_data_type, IPD_control_type, kind_phys => IPD_kind_phys
@@ -702,9 +702,8 @@ contains
                       Atm(n)%pkz,  Atm(n)%phis,  Atm(n)%q_con,                  &
                       Atm(n)%omga, Atm(n)%ua,    Atm(n)%va, Atm(n)%uc,          &
                       Atm(n)%vc,                                                &
-!The following three variables are used for SA-3D-TKE
-                      Atm(n)%deform_1,Atm(n)%deform_2,                          &
-                      Atm(n)%deform_3,Atm(n)%dku3d_h,Atm(n)%dku3d_e,            &
+!The following variable is used for SA-3D-TKE (kyf) (modify for data structure)
+                      Atm(n)%sa3dtke_var,                                       &
                       Atm(n)%ak,    Atm(n)%bk, Atm(n)%mfx,                      &
                       Atm(n)%mfy , Atm(n)%cx,    Atm(n)%cy, Atm(n)%ze0,         &
                       Atm(n)%flagstruct%hybrid_z,                               &
@@ -1907,9 +1906,8 @@ contains
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
-!The following three variables are used for SA-3D-TKE
-                     Atm(mygrid)%deform_1,Atm(mygrid)%deform_2,                   &
-                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e,  &
+!The following variable is used for SA-3D-TKE (kyf) (modify for data structure)
+                     Atm(mygrid)%sa3dtke_var,                   &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -1927,9 +1925,8 @@ contains
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
-!The following three variables are used for SA-3D-TKE
-                     Atm(mygrid)%deform_1, Atm(mygrid)%deform_2,          &
-                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e, &
+!The following three variables are used for SA-3D-TKE (kyf) (modify for data structure)
+                     Atm(mygrid)%sa3dtke_var,          &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -2008,9 +2005,8 @@ contains
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
-!The following three variables are used for SA-3D-TKE
-                     Atm(mygrid)%deform_1,Atm(mygrid)%deform_2,       &
-                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e,  &
+!The following three variables are used for SA-3D-TKE (kyf) (modify for data structure)
+                     Atm(mygrid)%sa3dtke_var,       &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -2027,9 +2023,8 @@ contains
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
-!The following three variables are used for SA-3D-TKE
-                     Atm(mygrid)%deform_1,Atm(mygrid)%deform_2,       &
-                     Atm(mygrid)%deform_3,Atm(mygrid)%dku3d_h,Atm(mygrid)%dku3d_e,  &
+!The following three variables are used for SA-3D-TKE (kyf) (modify for data structure)
+                     Atm(mygrid)%sa3dtke_var,       &
                      Atm(mygrid)%ak, Atm(mygrid)%bk, Atm(mygrid)%mfx, Atm(mygrid)%mfy,                    &
                      Atm(mygrid)%cx, Atm(mygrid)%cy, Atm(mygrid)%ze0, Atm(mygrid)%flagstruct%hybrid_z,    &
                      Atm(mygrid)%gridstruct, Atm(mygrid)%flagstruct,                            &
@@ -2178,9 +2173,9 @@ contains
             j = Atm_block%index(nb)%jj(ix)
             ! SA-3D-TKE (added im) (kyf)
             im = IPD_control%chunk_begin(nb)+ix-1
-            ! SA-3D-TKE (modified IPD_Tbd and ix into im) (kyf)
-            Atm(mygrid)%dku3d_h(i,j,k) = IPD_Tbd%dku3d_h(im,k1)
-            Atm(mygrid)%dku3d_e(i,j,k) = IPD_Tbd%dku3d_e(im,k1)
+            ! SA-3D-TKE (modified IPD_Tbd and ix into im) (kyf) (modify for data structure)
+            Atm(mygrid)%sa3dtke_var%dku3d_h(i,j,k) = IPD_Tbd%dku3d_h(im,k1)
+            Atm(mygrid)%sa3dtke_var%dku3d_e(i,j,k) = IPD_Tbd%dku3d_e(im,k1)
           enddo
         enddo
        endif
@@ -2208,11 +2203,11 @@ contains
          endif
          IPD_Statein%vvl(im,k) = _DBL_(_RL_(Atm(mygrid)%omga(i,j,k1)))
          IPD_Statein%prsl(im,k) = _DBL_(_RL_(Atm(mygrid)%delp(i,j,k1)))   ! Total mass
-!The following is for SA-3D-TKE
+!The following is for SA-3D-TKE (kyf) (modify for data structure)
          if(Atm(mygrid)%flagstruct%sa3dtke_dyco) then
-          IPD_Statein%def_1(ix,k) = _DBL_(_RL_(Atm(mygrid)%deform_1(i,j,k1)))
-          IPD_Statein%def_2(ix,k) = _DBL_(_RL_(Atm(mygrid)%deform_2(i,j,k1)))
-          IPD_Statein%def_3(ix,k) = _DBL_(_RL_(Atm(mygrid)%deform_3(i,j,k1)))
+          IPD_Statein%def_1(ix,k) = _DBL_(_RL_(Atm(mygrid)%sa3dtke_var%deform_1(i,j,k1)))
+          IPD_Statein%def_2(ix,k) = _DBL_(_RL_(Atm(mygrid)%sa3dtke_var%deform_2(i,j,k1)))
+          IPD_Statein%def_3(ix,k) = _DBL_(_RL_(Atm(mygrid)%sa3dtke_var%deform_3(i,j,k1)))
          endif
 
          if (Atm(mygrid)%flagstruct%do_skeb) IPD_Statein%diss_est(im,k) = _DBL_(_RL_(Atm(mygrid)%diss_est(i,j,k1)))

--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -695,8 +695,6 @@ contains
 !                     Atm(n)%flagstruct%n_split, Atm(n)%flagstruct%q_split,     &
                       Atm(n)%u,    Atm(n)%v,     Atm(n)%w,  Atm(n)%delz,        &
                       Atm(n)%flagstruct%hydrostatic,                            &
-!The following variable is used for SA-3D-TKE
-                      Atm(n)%flagstruct%sa3dtke_dyco,                           &
                       Atm(n)%pt  , Atm(n)%delp,  Atm(n)%q,  Atm(n)%ps,          &
                       Atm(n)%pe,   Atm(n)%pk,    Atm(n)%peln,                   &
                       Atm(n)%pkz,  Atm(n)%phis,  Atm(n)%q_con,                  &
@@ -1901,8 +1899,6 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq,  n_split_loc,                                       &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
-!The following variable is used for SA-3D-TKE
-                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
@@ -1920,8 +1916,6 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq, n_split_loc,                                        &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
-!The following variable is used for SA-3D-TKE
-                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
@@ -2000,8 +1994,6 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq, Atm(mygrid)%flagstruct%n_split,        &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
-!The following variable is used for SA-3D-TKE
-                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &
@@ -2018,8 +2010,6 @@ contains
                      Atm(mygrid)%ptop, Atm(mygrid)%ks, nq, Atm(mygrid)%flagstruct%n_split,        &
                      Atm(mygrid)%flagstruct%q_split, Atm(mygrid)%u, Atm(mygrid)%v, Atm(mygrid)%w,         &
                      Atm(mygrid)%delz, Atm(mygrid)%flagstruct%hydrostatic,                      &
-!The following variable is used for SA-3D-TKE
-                     Atm(mygrid)%flagstruct%sa3dtke_dyco,                      &
                      Atm(mygrid)%pt, Atm(mygrid)%delp, Atm(mygrid)%q, Atm(mygrid)%ps,                     &
                      Atm(mygrid)%pe, Atm(mygrid)%pk, Atm(mygrid)%peln, Atm(mygrid)%pkz, Atm(mygrid)%phis,      &
                      Atm(mygrid)%q_con, Atm(mygrid)%omga, Atm(mygrid)%ua, Atm(mygrid)%va, Atm(mygrid)%uc, Atm(mygrid)%vc, &

--- a/model/dyn_core.F90
+++ b/model/dyn_core.F90
@@ -897,22 +897,40 @@ contains
             enddo
          enddo
        endif
-       call d_sw(vt(isd,jsd,k), delp(isd,jsd,k), ptc(isd,jsd,k),  pt(isd,jsd,k),      &
-                  u(isd,jsd,k),    v(isd,jsd,k),   w(isd:,jsd:,k),  uc(isd,jsd,k),      &
-                  vc(isd,jsd,k),   ua(isd,jsd,k),  va(isd,jsd,k), divgd(isd,jsd,k),   &
-                  mfx(is, js, k),  mfy(is, js, k),  cx(is, jsd,k),  cy(isd,js, k),    &
-!The following variable is for SA-3D-TKE (kyf) (modify for data structure)
-                  sa3dtke_var%dku3d_h(isd, jsd, k), &
-                  crx(is, jsd,k),  cry(isd,js, k), xfx(is, jsd,k), yfx(isd,js, k),    &
+
+       if(flagstruct%sa3dtke_dyco) then
+          call d_sw(vt(isd,jsd,k), delp(isd,jsd,k), ptc(isd,jsd,k),  pt(isd,jsd,k),      &
+                    u(isd,jsd,k),    v(isd,jsd,k),   w(isd:,jsd:,k),  uc(isd,jsd,k),      &
+                    vc(isd,jsd,k),   ua(isd,jsd,k),  va(isd,jsd,k), divgd(isd,jsd,k),   &
+                    mfx(is, js, k),  mfy(is, js, k),  cx(is, jsd,k),  cy(isd,js, k),    &
+                    crx(is, jsd,k),  cry(isd,js, k), xfx(is, jsd,k), yfx(isd,js, k),    &
 #ifdef USE_COND
-                  q_con(isd:,jsd:,k),  z_rat(isd,jsd),  &
+                    q_con(isd:,jsd:,k),  z_rat(isd,jsd),  &
 #else
-                  q_con(isd:,jsd:,1),  z_rat(isd,jsd),  &
+                    q_con(isd:,jsd:,1),  z_rat(isd,jsd),  &
 #endif
-                  kgb, heat_s, diss_e,zvir, sphum, nq,  q,  k,  npz, flagstruct%inline_q,  dt,  &
-                  flagstruct%hord_tr, hord_m, hord_v, hord_t, hord_p,    &
-                  nord_k, nord_v(k), nord_w, nord_t, flagstruct%dddmp, d2_divg, flagstruct%d4_bg,  &
-                  damp_vt(k), damp_w, damp_t, d_con_k, hydrostatic, gridstruct, flagstruct, bd)
+                    kgb, heat_s, diss_e,zvir, sphum, nq,  q,  k,  npz, flagstruct%inline_q,  dt,  &
+                    flagstruct%hord_tr, hord_m, hord_v, hord_t, hord_p,    &
+                    nord_k, nord_v(k), nord_w, nord_t, flagstruct%dddmp, d2_divg, flagstruct%d4_bg,  &
+                    damp_vt(k), damp_w, damp_t, d_con_k, hydrostatic, gridstruct, flagstruct, bd,  &
+!The following optional variable is for SA-3D-TKE (kyf)
+                    sa3dtke_var%dku3d_h(isd, jsd, k) )
+       else
+          call d_sw(vt(isd,jsd,k), delp(isd,jsd,k), ptc(isd,jsd,k),  pt(isd,jsd,k),      &
+                    u(isd,jsd,k),    v(isd,jsd,k),   w(isd:,jsd:,k),  uc(isd,jsd,k),      &
+                    vc(isd,jsd,k),   ua(isd,jsd,k),  va(isd,jsd,k), divgd(isd,jsd,k),   &
+                    mfx(is, js, k),  mfy(is, js, k),  cx(is, jsd,k),  cy(isd,js, k),    &
+                    crx(is, jsd,k),  cry(isd,js, k), xfx(is, jsd,k), yfx(isd,js, k),    &
+#ifdef USE_COND
+                    q_con(isd:,jsd:,k),  z_rat(isd,jsd),  &
+#else
+                    q_con(isd:,jsd:,1),  z_rat(isd,jsd),  &
+#endif
+                    kgb, heat_s, diss_e,zvir, sphum, nq,  q,  k,  npz, flagstruct%inline_q,  dt,  &
+                    flagstruct%hord_tr, hord_m, hord_v, hord_t, hord_p,    &
+                    nord_k, nord_v(k), nord_w, nord_t, flagstruct%dddmp, d2_divg, flagstruct%d4_bg,  &
+                    damp_vt(k), damp_w, damp_t, d_con_k, hydrostatic, gridstruct, flagstruct, bd)
+       endif
 
        if((.not.flagstruct%use_old_omega) .and. last_step ) then
 ! Average horizontal "convergence" to cell center

--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -929,6 +929,8 @@ module fv_arrays_mod
   logical :: regional_bcs_from_gsi = .false.    !< Default setting for writing restart files with boundary rows
   logical :: pass_full_omega_to_physics_in_non_hydrostatic_mode = .false.  !< Default to passing local omega to physics in non-hydrostatic 
 
+!This logical variable is used for SA-3D-TKE
+     logical :: sa3dtke_dyco = .false.
 
   !>Convenience pointers
   integer, pointer :: grid_number
@@ -1284,7 +1286,13 @@ module fv_arrays_mod
     real, _ALLOCATABLE :: va(:,:,:)     _NULL
     real, _ALLOCATABLE :: uc(:,:,:)     _NULL  !< (uc, vc) are mostly used as the C grid winds
     real, _ALLOCATABLE :: vc(:,:,:)     _NULL
-
+!3D-SA-TKE
+    real, _ALLOCATABLE :: deform_1(:,:,:)  _NULL !< horizontal deformation
+    real, _ALLOCATABLE :: deform_2(:,:,:)  _NULL !< vertical deformation
+    real, _ALLOCATABLE :: deform_3(:,:,:)  _NULL !< 3D TKE transport & pressure correlation
+    real, _ALLOCATABLE :: dku3d_h(:,:,:)   _NULL !< 3D Horizontal Eddy Diffusivity for Momentum
+    real, _ALLOCATABLE :: dku3d_e(:,:,:)   _NULL !< 3D Eddy Diffusivity for TKE
+!3D-SA-TKE-end
     real, _ALLOCATABLE :: ak(:)  _NULL
     real, _ALLOCATABLE :: bk(:)  _NULL
 
@@ -1517,6 +1525,14 @@ contains
     allocate (   Atm%va(isd:ied  ,jsd:jed  ,npz) )
     allocate (   Atm%uc(isd:ied+1,jsd:jed  ,npz) )
     allocate (   Atm%vc(isd:ied  ,jsd:jed+1,npz) )
+!3D-SA-TKE
+    allocate (   Atm%deform_1(isd:ied  ,jsd:jed  ,npz) )
+    allocate (   Atm%deform_2(isd:ied  ,jsd:jed  ,npz) )
+    allocate (   Atm%deform_3(isd:ied  ,jsd:jed  ,npz) )
+    allocate (   Atm%dku3d_h(isd:ied  ,jsd:jed, npz) )
+    allocate (   Atm%dku3d_e(isd:ied  ,jsd:jed, npz) )
+!3D-SA-TKE-end
+
     ! For tracer transport:
     allocate ( Atm%mfx(is:ie+1, js:je,  npz) )
     allocate ( Atm%mfy(is:ie  , js:je+1,npz) )
@@ -1569,6 +1585,13 @@ contains
                 Atm%va(i,j,k) = real_big
                 Atm%pt(i,j,k) = real_big
               Atm%delp(i,j,k) = real_big
+!3D-SA-TKE
+                Atm%deform_1(i,j,k) = 0.
+                Atm%deform_2(i,j,k) = 0.
+                Atm%deform_3(i,j,k) = 0.
+                Atm%dku3d_h(i,j,k) = 0.
+                Atm%dku3d_e(i,j,k) = 0.
+!3D-SA-TKE-end
 #ifdef USE_COND
              Atm%q_con(i,j,k) = 0.
 #endif

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -394,6 +394,9 @@ module fv_control_mod
 
      integer, pointer :: ndims
 
+!The following is used for SA-3D-TKE
+     logical , pointer :: sa3dtke_dyco
+
      real(kind=R_GRID), pointer :: dx_const
      real(kind=R_GRID), pointer :: dy_const
      real(kind=R_GRID), pointer :: deglon_start, deglon_stop, &  ! boundaries of latlon patch
@@ -952,6 +955,10 @@ module fv_control_mod
        external_eta                  => Atm%flagstruct%external_eta
        read_increment                => Atm%flagstruct%read_increment
        increment_file_on_native_grid => Atm%flagstruct%increment_file_on_native_grid
+
+!The following is used for SA-3D-TKE
+       sa3dtke_dyco                  => Atm%flagstruct%sa3dtke_dyco
+
        hydrostatic                   => Atm%flagstruct%hydrostatic
        phys_hydrostatic              => Atm%flagstruct%phys_hydrostatic
        use_hydro_pressure            => Atm%flagstruct%use_hydro_pressure
@@ -1081,6 +1088,8 @@ module fv_control_mod
             consv_te, fill, filter_phys, fill_dp, fill_wz, fill_gfs, consv_am, RF_fast, &
             range_warn, dwind_2d, inline_q, z_tracer, reproduce_sum, adiabatic, do_vort_damp, no_dycore,   &
             tau, tau_w, fast_tau_w_sec, tau_h2o, rf_cutoff, nf_omega, hydrostatic, fv_sg_adj, sg_cutoff, breed_vortex_inline,  &
+!The following is used for SA-3D-TKE
+            sa3dtke_dyco, &
             na_init, nudge_dz, hybrid_z, Make_NH, n_zs_filter, nord_zs_filter, full_zs_filter, reset_eta,         &
             pnats, dnats, dnrts, a2b_ord, remap_t, p_ref, d2_bg_k1, d2_bg_k2,  &
             c2l_ord, dx_const, dy_const, umax, deglat,      &

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -187,8 +187,13 @@ contains
 
   subroutine fv_dynamics(npx, npy, npz, nq_tot,  ng, bdt, consv_te, fill,             &
                         reproduce_sum, kappa, cp_air, zvir, ptop, ks, ncnst, n_split, &
-                        q_split, u, v, w, delz, hydrostatic, pt, delp, q,             &
+                        q_split, u, v, w, delz, hydrostatic,                          &
+!The following variable is for SA-3D-TKE
+                        sa3dtke_dyco,                                                 &
+                        pt, delp, q,                                                  &
                         ps, pe, pk, peln, pkz, phis, q_con, omga, ua, va, uc, vc,     &
+!The following three variables are for SA-3D-TKE
+                        deform_1, deform_2, deform_3, dku3d_h, dku3d_e,               &
                         ak, bk, mfx, mfy, cx, cy, ze0, hybrid_z,                      &
                         gridstruct, flagstruct, neststruct, idiag, bd,                &
                         parent_grid, domain, diss_est, inline_mp)
@@ -255,6 +260,14 @@ contains
     real, intent(inout) :: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
 
     real, intent(inout), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: ua, va
+    !The following 4 variables are for SA-3D-TKE
+    logical, intent(in) :: sa3dtke_dyco
+    real, intent(out), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: deform_1
+    real, intent(out), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: deform_2
+    real, intent(out), dimension(bd%isd:bd%ied, bd%jsd:bd%jed, npz):: deform_3
+    real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: dku3d_h
+    real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: dku3d_e
+
     real, intent(in),    dimension(npz+1):: ak, bk
 
     type(inline_mp_type), intent(inout) :: inline_mp
@@ -666,7 +679,11 @@ contains
 #endif
                     grav, hydrostatic, &
                     u, v, w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va,           &
-                    uc, vc, mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, ks, &
+                    uc, vc,            &
+!The following 6 variables are for SA-3D-TKE
+                    sa3dtke_dyco, deform_1, deform_2,        &
+                    deform_3, dku3d_h, dku3d_e,              &
+                    mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, ks, &
                     gridstruct, flagstruct, neststruct, idiag, bd, &
                     domain, n_map==1, i_pack, GFDL_interstitial%last_step, diss_est,time_total)
                                            call timing_off('DYN_CORE')

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -189,8 +189,6 @@ contains
   subroutine fv_dynamics(npx, npy, npz, nq_tot,  ng, bdt, consv_te, fill,             &
                         reproduce_sum, kappa, cp_air, zvir, ptop, ks, ncnst, n_split, &
                         q_split, u, v, w, delz, hydrostatic,                          &
-!The following variable is for SA-3D-TKE
-                        sa3dtke_dyco,                                                 &
                         pt, delp, q,                                                  &
                         ps, pe, pk, peln, pkz, phis, q_con, omga, ua, va, uc, vc,     &
 !The following variable is for SA-3D-TKE (kyf) (modify for data structure)
@@ -262,7 +260,6 @@ contains
 
     real, intent(inout), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: ua, va
     !The following variable is for SA-3D-TKE (kyf) (modify for data structure)
-    logical, intent(in) :: sa3dtke_dyco
 
     real, intent(in),    dimension(npz+1):: ak, bk
     ! For SA-3D-TKE (kyf) (modify for data structure)
@@ -677,8 +674,8 @@ contains
                     grav, hydrostatic, &
                     u, v, w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va,           &
                     uc, vc,            &
-!The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
-                    sa3dtke_dyco, sa3dtke_var,        &
+!The following variable is for SA-3D-TKE (kyf) (modify for data structure)
+                    sa3dtke_var,        &
                     mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, ks, &
                     gridstruct, flagstruct, neststruct, idiag, bd, &
                     domain, n_map==1, i_pack, GFDL_interstitial%last_step, diss_est,time_total)

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -156,6 +156,7 @@ module fv_dynamics_mod
    use fv_regional_mod,     only: current_time_in_seconds
    use boundary_mod,        only: nested_grid_BC_apply_intT
    use fv_arrays_mod,       only: fv_grid_type, fv_flags_type, fv_atmos_type, fv_nest_type, fv_diag_type, fv_grid_bounds_type, inline_mp_type
+   use fv_arrays_mod,       only: sa3dtke_type ! for SA-3D-TKE (kyf) (modify for data structure)
    use fv_nwp_nudge_mod,    only: do_adiabatic_init
    use time_manager_mod,    only: get_time
 
@@ -192,8 +193,8 @@ contains
                         sa3dtke_dyco,                                                 &
                         pt, delp, q,                                                  &
                         ps, pe, pk, peln, pkz, phis, q_con, omga, ua, va, uc, vc,     &
-!The following three variables are for SA-3D-TKE
-                        deform_1, deform_2, deform_3, dku3d_h, dku3d_e,               &
+!The following variable is for SA-3D-TKE (kyf) (modify for data structure)
+                        sa3dtke_var,                                                  &
                         ak, bk, mfx, mfy, cx, cy, ze0, hybrid_z,                      &
                         gridstruct, flagstruct, neststruct, idiag, bd,                &
                         parent_grid, domain, diss_est, inline_mp)
@@ -260,16 +261,12 @@ contains
     real, intent(inout) :: vc(bd%isd:bd%ied  ,bd%jsd:bd%jed+1,npz)
 
     real, intent(inout), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: ua, va
-    !The following 4 variables are for SA-3D-TKE
+    !The following variable is for SA-3D-TKE (kyf) (modify for data structure)
     logical, intent(in) :: sa3dtke_dyco
-    real, intent(out), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: deform_1
-    real, intent(out), dimension(bd%isd:bd%ied ,bd%jsd:bd%jed ,npz):: deform_2
-    real, intent(out), dimension(bd%isd:bd%ied, bd%jsd:bd%jed, npz):: deform_3
-    real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: dku3d_h
-    real, intent(inout), dimension(bd%isd:bd%ied,bd%jsd:bd%jed,npz):: dku3d_e
 
     real, intent(in),    dimension(npz+1):: ak, bk
-
+    ! For SA-3D-TKE (kyf) (modify for data structure)
+    type(sa3dtke_type), intent(inout) :: sa3dtke_var
     type(inline_mp_type), intent(inout) :: inline_mp
 
 ! Accumulated Mass flux arrays: the "Flux Capacitor"
@@ -680,9 +677,8 @@ contains
                     grav, hydrostatic, &
                     u, v, w, delz, pt, q, delp, pe, pk, phis, ws, omga, ptop, pfull, ua, va,           &
                     uc, vc,            &
-!The following 6 variables are for SA-3D-TKE
-                    sa3dtke_dyco, deform_1, deform_2,        &
-                    deform_3, dku3d_h, dku3d_e,              &
+!The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
+                    sa3dtke_dyco, sa3dtke_var,        &
                     mfx, mfy, cx, cy, pkz, peln, q_con, ak, bk, ks, &
                     gridstruct, flagstruct, neststruct, idiag, bd, &
                     domain, n_map==1, i_pack, GFDL_interstitial%last_step, diss_est,time_total)

--- a/model/nh_utils.F90
+++ b/model/nh_utils.F90
@@ -70,6 +70,9 @@ module nh_utils_mod
    public sim_solver, sim1_solver, sim3_solver
    public sim3p0_solver, rim_2d
    public Riem_Solver_c
+!This is for sa3dtke
+   public edge_profile1
+
 
    real, parameter:: r3 = 1./3.
 
@@ -1946,6 +1949,73 @@ CONTAINS
     enddo
 
  end subroutine edge_profile
+
+ subroutine edge_profile1(q1, q1e, i1, i2, km, dp0, limiter)
+! Edge profiles for a single scalar quantity
+ integer, intent(in):: i1, i2
+ integer, intent(in):: km
+ integer, intent(in):: limiter
+ real, intent(in):: dp0(km)
+ real, intent(in),  dimension(i1:i2,km):: q1
+ real, intent(out), dimension(i1:i2,km+1):: q1e
+!-----------------------------------------------------------------------
+ real, dimension(i1:i2,km+1):: qe1, gam  ! edge values
+ real  gak(km)
+ real  bet, r2o3, r4o3
+ real  g0, gk, xt1, xt2, a_bot
+ integer i, k
+
+! Assuming grid varying in vertical only
+   g0 = dp0(2) / dp0(1)
+  xt1 = 2.*g0*(g0+1. )
+  bet =    g0*(g0+0.5)
+  do i=i1,i2
+      qe1(i,1) = ( xt1*q1(i,1) + q1(i,2) ) / bet
+      gam(i,1) = ( 1. + g0*(g0+1.5) ) / bet
+  enddo
+
+  do k=2,km
+     gk = dp0(k-1) / dp0(k)
+     do i=i1,i2
+             bet =  2. + 2.*gk - gam(i,k-1)
+        qe1(i,k) = ( 3.*(q1(i,k-1)+gk*q1(i,k)) - qe1(i,k-1) ) / bet
+        gam(i,k) = gk / bet
+     enddo
+  enddo
+
+  a_bot = 1. + gk*(gk+1.5)
+    xt1 =   2.*gk*(gk+1.)
+  do i=i1,i2
+             xt2 = gk*(gk+0.5) - a_bot*gam(i,km)
+     qe1(i,km+1) = ( xt1*q1(i,km) + q1(i,km-1) - a_bot*qe1(i,km) ) / xt2
+  enddo
+
+  do k=km,1,-1
+     do i=i1,i2
+        qe1(i,k) = qe1(i,k) - gam(i,k)*qe1(i,k+1)
+     enddo
+  enddo
+
+!------------------
+! Apply constraints
+!------------------
+    if ( limiter/=0 ) then   ! limit the top & bottom winds
+         do i=i1,i2
+! Top
+            if ( q1(i,1)*qe1(i,1) < 0. ) qe1(i,1) = 0.
+! Surface:
+            if ( q1(i,km)*qe1(i,km+1) < 0. ) qe1(i,km+1) = 0.
+         enddo
+    endif
+
+    do k=1,km+1
+       do i=i1,i2
+          q1e(i,k) = qe1(i,k)
+       enddo
+    enddo
+
+  end subroutine edge_profile1
+
 
  subroutine edge_profile_0grad(q1, q2, q1e, q2e, i1, i2, j1, j2, j, km, dp0, uniform_grid, limiter)
 ! Optimized for wind profile reconstruction:

--- a/model/sw_core.F90
+++ b/model/sw_core.F90
@@ -50,7 +50,6 @@
                               deln_flux_explm, deln_flux_explm_udvd
  use fv_mp_mod, only: is_master, fill_corners, XDir, YDir
  use fv_arrays_mod, only: fv_grid_type, fv_grid_bounds_type, fv_flags_type
- !use fv_arrays_mod, only: sa3dtke_type ! for SA-3D-TKE (kyf) (modify for data structure) 
  use a2b_edge_mod, only: a2b_ord4
 
 #ifdef SW_DYNAMICS
@@ -522,13 +521,13 @@
 !! and other prognostic varaiables.
    subroutine d_sw(delpc, delp,  ptc,   pt, u,  v, w, uc,vc, &
                    ua, va, divg_d, xflux, yflux, cx, cy,              &
-!The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
-                   dku3d_h,                    &
                    crx_adv, cry_adv,  xfx_adv, yfx_adv, q_con, z_rat, kgb, heat_source,diss_est,  &
                    zvir, sphum, nq, q, k, km, inline_q,  &
                    dt, hord_tr, hord_mt, hord_vt, hord_tm, hord_dp, nord,   &
                    nord_v, nord_w, nord_t, dddmp, d2_bg, d4_bg, damp_v, damp_w, &
-                   damp_t, d_con, hydrostatic, gridstruct, flagstruct, bd)
+                   damp_t, d_con, hydrostatic, gridstruct, flagstruct, bd, &
+!The following optional variable is for SA-3D-TKE (kyf)
+                   dku3d_h)
 
       integer, intent(IN):: hord_tr, hord_mt, hord_vt, hord_tm, hord_dp
       integer, intent(IN):: nord   !< nord=1 divergence damping; (del-4) or 3 (del-8)
@@ -540,9 +539,6 @@
       real   , intent(IN):: zvir
       real,    intent(in):: damp_v, damp_w, damp_t, kgb
       type(fv_grid_bounds_type), intent(IN) :: bd
-!The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
-      !type(sa3dtke_type), intent(in) :: sa3dtke_var
-      real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: dku3d_h 
 
       real, intent(inout):: divg_d(bd%isd:bd%ied+1,bd%jsd:bd%jed+1) !< divergence
       real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: z_rat
@@ -566,6 +562,8 @@
       real, intent(OUT), dimension(bd%isd:bd%ied,bd%js:bd%je+1):: cry_adv, yfx_adv
       type(fv_grid_type), intent(IN), target :: gridstruct
       type(fv_flags_type), intent(IN), target :: flagstruct
+!The following optional variable is for SA-3D-TKE (kyf)
+      real, intent(IN), optional, dimension(bd%isd:bd%ied,bd%jsd:bd%jed):: dku3d_h
 ! Local:
       logical:: sw_corner, se_corner, ne_corner, nw_corner
       real :: ut(bd%isd:bd%ied+1,bd%jsd:bd%jed)

--- a/model/sw_core.F90
+++ b/model/sw_core.F90
@@ -50,6 +50,7 @@
                               deln_flux_explm, deln_flux_explm_udvd
  use fv_mp_mod, only: is_master, fill_corners, XDir, YDir
  use fv_arrays_mod, only: fv_grid_type, fv_grid_bounds_type, fv_flags_type
+ !use fv_arrays_mod, only: sa3dtke_type ! for SA-3D-TKE (kyf) (modify for data structure) 
  use a2b_edge_mod, only: a2b_ord4
 
 #ifdef SW_DYNAMICS
@@ -521,7 +522,7 @@
 !! and other prognostic varaiables.
    subroutine d_sw(delpc, delp,  ptc,   pt, u,  v, w, uc,vc, &
                    ua, va, divg_d, xflux, yflux, cx, cy,              &
-!The following 5 variables are for SA-3D-TKE
+!The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
                    sa3dtke_dyco, dku3d_h,                    &
                    crx_adv, cry_adv,  xfx_adv, yfx_adv, q_con, z_rat, kgb, heat_source,diss_est,  &
                    zvir, sphum, nq, q, k, km, inline_q,  &
@@ -539,9 +540,10 @@
       real   , intent(IN):: zvir
       real,    intent(in):: damp_v, damp_w, damp_t, kgb
       type(fv_grid_bounds_type), intent(IN) :: bd
-!The following 5 variables are for SA-3D-TKE
+!The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
       logical, intent(IN):: sa3dtke_dyco
-      real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: dku3d_h
+      !type(sa3dtke_type), intent(in) :: sa3dtke_var
+      real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: dku3d_h 
 
       real, intent(inout):: divg_d(bd%isd:bd%ied+1,bd%jsd:bd%jed+1) !< divergence
       real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: z_rat
@@ -1461,7 +1463,7 @@
         do i=is,ie+1
 !The following is for SA-3D-TKE
           if(sa3dtke_dyco) then
-           damp2 = abs(dt)*dku3d_h(i,j)
+           damp2 = abs(dt)*dku3d_h(i,j) 
           else
            damp2 =  gridstruct%da_min_c*max(d2_bg, min(0.20, dddmp*vort(i,j)))  ! del-2
           endif

--- a/model/sw_core.F90
+++ b/model/sw_core.F90
@@ -521,6 +521,8 @@
 !! and other prognostic varaiables.
    subroutine d_sw(delpc, delp,  ptc,   pt, u,  v, w, uc,vc, &
                    ua, va, divg_d, xflux, yflux, cx, cy,              &
+!The following 5 variables are for SA-3D-TKE
+                   sa3dtke_dyco, dku3d_h,                    &
                    crx_adv, cry_adv,  xfx_adv, yfx_adv, q_con, z_rat, kgb, heat_source,diss_est,  &
                    zvir, sphum, nq, q, k, km, inline_q,  &
                    dt, hord_tr, hord_mt, hord_vt, hord_tm, hord_dp, nord,   &
@@ -537,6 +539,10 @@
       real   , intent(IN):: zvir
       real,    intent(in):: damp_v, damp_w, damp_t, kgb
       type(fv_grid_bounds_type), intent(IN) :: bd
+!The following 5 variables are for SA-3D-TKE
+      logical, intent(IN):: sa3dtke_dyco
+      real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: dku3d_h
+
       real, intent(inout):: divg_d(bd%isd:bd%ied+1,bd%jsd:bd%jed+1) !< divergence
       real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: z_rat
       real, intent(INOUT), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: delp, pt, ua, va
@@ -1453,7 +1459,13 @@
 
      do j=js,je+1
         do i=is,ie+1
+!The following is for SA-3D-TKE
+          if(sa3dtke_dyco) then
+           damp2 = abs(dt)*dku3d_h(i,j)
+          else
            damp2 =  gridstruct%da_min_c*max(d2_bg, min(0.20, dddmp*vort(i,j)))  ! del-2
+          endif
+
            vort(i,j) = damp2*delpc(i,j) + dd8*divg_d(i,j)
              ke(i,j) = ke(i,j) + vort(i,j)
         enddo

--- a/model/sw_core.F90
+++ b/model/sw_core.F90
@@ -523,7 +523,7 @@
    subroutine d_sw(delpc, delp,  ptc,   pt, u,  v, w, uc,vc, &
                    ua, va, divg_d, xflux, yflux, cx, cy,              &
 !The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
-                   sa3dtke_dyco, dku3d_h,                    &
+                   dku3d_h,                    &
                    crx_adv, cry_adv,  xfx_adv, yfx_adv, q_con, z_rat, kgb, heat_source,diss_est,  &
                    zvir, sphum, nq, q, k, km, inline_q,  &
                    dt, hord_tr, hord_mt, hord_vt, hord_tm, hord_dp, nord,   &
@@ -541,7 +541,6 @@
       real,    intent(in):: damp_v, damp_w, damp_t, kgb
       type(fv_grid_bounds_type), intent(IN) :: bd
 !The following 2 variables are for SA-3D-TKE (kyf) (modify for data structure)
-      logical, intent(IN):: sa3dtke_dyco
       !type(sa3dtke_type), intent(in) :: sa3dtke_var
       real, intent(IN), dimension(bd%isd:bd%ied,  bd%jsd:bd%jed):: dku3d_h 
 
@@ -1462,7 +1461,7 @@
      do j=js,je+1
         do i=is,ie+1
 !The following is for SA-3D-TKE
-          if(sa3dtke_dyco) then
+          if(flagstruct%sa3dtke_dyco) then
            damp2 = abs(dt)*dku3d_h(i,j) 
           else
            damp2 =  gridstruct%da_min_c*max(d2_bg, min(0.20, dddmp*vort(i,j)))  ! del-2


### PR DESCRIPTION
**Description**

Enable the scale-aware 3DTKE capability for the GFS TKE EDMF PBL scheme developed by Prof. Ping Zhu (@zhup01) from FIU and his group (e.g., @samuelkyfung).

Related publication: https://www.nature.com/articles/s41612-025-01117-6

Fixes ufs-community/ufs-weather-model/issues/2732

Related pull requests:
- NOAA-EMC/fv3atm/pull/963
- ufs-community/ccpp-physics/pull/279
- ufs-community/ufs-weather-model/pull/2734

**How Has This Been Tested?**

Tests conducted with the UFS HAFS application. Regression tests within ufs-weather-model passed.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
