### PR TITLE
Fix pressure variable calculationduring adiabatic initialization `na_init>0`

### DIFF
--- a/driver/SHiELDFULL/atmosphere.F90
+++ b/driver/SHiELDFULL/atmosphere.F90
@@ -1421,6 +1421,10 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
      allocate ( v0(isc:iec+1,jsc:jec,   npz) )
      allocate (dp0(isc:iec,jsc:jec, npz) )
 
+     call p_adi(Atm(mygrid)%npz, Atm(mygrid)%ng, isc, iec, jsc, jec, Atm(mygrid)%ptop,  &
+                Atm(mygrid)%delp, Atm(mygrid)%pt, Atm(mygrid)%ps, Atm(mygrid)%pe,     &
+                Atm(mygrid)%peln, Atm(mygrid)%pk, Atm(mygrid)%pkz, Atm(mygrid)%flagstruct%hydrostatic)
+
      if ( Atm(mygrid)%flagstruct%hydrostatic ) nudge_dz = .false.
 
      if ( nudge_dz ) then
@@ -1547,6 +1551,10 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
 
        enddo
 
+     call p_adi(Atm(mygrid)%npz, Atm(mygrid)%ng, isc, iec, jsc, jec, Atm(mygrid)%ptop,  &
+                Atm(mygrid)%delp, Atm(mygrid)%pt, Atm(mygrid)%ps, Atm(mygrid)%pe,     &
+                Atm(mygrid)%peln, Atm(mygrid)%pk, Atm(mygrid)%pkz, Atm(mygrid)%flagstruct%hydrostatic)
+
 ! Backward
     call fv_dynamics(Atm(mygrid)%npx, Atm(mygrid)%npy, npz,  nq, Atm(mygrid)%ng, -dt_atmos, 0.,      &
                      Atm(mygrid)%flagstruct%fill, Atm(mygrid)%flagstruct%reproduce_sum, kappa, cp_air, zvir,  &
@@ -1608,6 +1616,10 @@ if ( is_master() ) write(*,*) 'CALL atmos_global_diag_init'
        enddo
 
      enddo
+
+     call p_adi(Atm(mygrid)%npz, Atm(mygrid)%ng, isc, iec, jsc, jec, Atm(mygrid)%ptop,  &
+                Atm(mygrid)%delp, Atm(mygrid)%pt, Atm(mygrid)%ps, Atm(mygrid)%pe,     &
+                Atm(mygrid)%peln, Atm(mygrid)%pk, Atm(mygrid)%pkz, Atm(mygrid)%flagstruct%hydrostatic)
 
      deallocate ( u0 )
      deallocate ( v0 )


### PR DESCRIPTION
This PR corrects the calculation of pressure-related variables when adiabatic initialization is enabled.
Previously, inconsistencies between `delp` and the pressure edges `pe` and `peln` lead to incorrect values of `p_bot` and `z_bot`, particularly in the lowest model level. This was especially problematic in coupled configurations, where such inconsistencies caused unphysical values (e.g., `z_bot<0`) and model crashes.