### PR TITLE
Bring in -check all and -ftrapuv to DEBUG intell builds

### DIFF
--- a/cmake/compiler_flags_IntelLLVM_Fortran.cmake
+++ b/cmake/compiler_flags_IntelLLVM_Fortran.cmake
@@ -10,7 +10,7 @@ set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverrid
 
 set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal -fp-model strict -qoverride-limits")
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays")
 
 set(CMAKE_Fortran_LINK_FLAGS "")
 

--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -10,7 +10,7 @@ set(CMAKE_Fortran_FLAGS_REPRO "-O2 -debug minimal -fp-model consistent -qoverrid
 
 set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3")
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv -init=snan,arrays")
 
 set(CMAKE_Fortran_LINK_FLAGS "")
 


### PR DESCRIPTION
**Description**
Add DEBUG intel build flags to meet some NCO standard in ops

**How Has This Been Tested?**
This will be tested using the UFSWM regression testing system.

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
