### PR TITLE
add cpl_imp_mrg and dbg to atmos_model nml

### DIFF
--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -332,8 +332,10 @@ contains
    logical :: sync         = .false.
    logical :: ignore_rst_cksum = .false.
    real    :: avg_max_length = 3600.
+   logical :: cpl_imp_mrg = .false.
+   logical :: cpl_imp_dbg = .false.
    namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, ccpp_suite, avg_max_length, &
-                              ignore_rst_cksum
+                              ignore_rst_cksum, cpl_imp_mrg, cpl_imp_dbg
    ! *DH 20210326
 
    !For regional


### PR DESCRIPTION
**Description**

Adds two namelist variables to atmos_model nml file. This is in a section of driver/UFS/atmosphere.F90 which is remarked as 'temporary work-around', however I am not aware of any work to remove the work-around.

Fixes # (issue)

- fixes https://github.com/NOAA-EMC/ufsatm/issues/1096

**How Has This Been Tested?**

UFS-WM RTs are B4B https://github.com/ufs-community/ufs-weather-model/pull/3229

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
