### PR TITLE
Define variables in hailcast to resolve warnings

### DIFF
--- a/tools/module_diag_hailcast.F90
+++ b/tools/module_diag_hailcast.F90
@@ -924,6 +924,15 @@ CONTAINS
       RTIME = 2000.
       IF (wdur .LT. RTIME) RTIME = wdur
 
+      WFZLP = 0.0
+      ZFZL = 0.0
+      RFZL = 0.0
+      VUFZL = 0.0
+      DENSAFZL = 0.0
+      VUMAX = 0.0
+      RI = 0.0
+      RW =0.0
+
       TFZL = tk_embryo
       CALL INTERPP(PA, WFZLP, TCA, tk_embryo, IFOUT, nz)
       CALL INTERP(h1d, ZFZL, WFZLP, IFOUT, PA, nz)


### PR DESCRIPTION
**Description**
 This PR brings in a fix that was used in the RRFS production branch. The fix initializes variables needed for hailcast. 

**How Has This Been Tested?**

This was tested using the regression test suite of the UFSWM. No baseline changes were expected to occur with this PR.

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
