### PR TITLE
Updates for ccpp-capgen v1

### DIFF
--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -498,12 +498,6 @@ contains
 
    ! Do CCPP fast physics initialization before call to adiabatic_init (since this calls fv_dynamics)
 
-   ! For fast physics running over the entire domain, block
-   ! and thread number are not used; set to safe values
-   !cdata%blk_no = 1
-   !cdata%thrd_no = 1
-   !cdata%thrd_cnt = 1
-
    ! Create shared data type for fast and slow physics, one for each thread
 #ifdef OPENMP
    nthreads = omp_get_max_threads()

--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -297,10 +297,9 @@ contains
 !! and diagnostics.
  subroutine atmosphere_init (Time_init, Time, Time_step, Grid_box, area)
 
-   use ccpp_static_api,   only: ccpp_physics_init
-   use CCPP_data,         only: ccpp_suite,          &
-                                cdata => cdata_tile, &
-                                GFDL_interstitial
+   use ufs_ccpp_cap,      only: ccpp_physics_init
+   use CCPP_driver,       only: ccpp_suite, errmsg, errflg
+   use CCPP_data,         only: GFDL_interstitial
 #ifdef OPENMP
    use omp_lib
 #endif
@@ -501,9 +500,9 @@ contains
 
    ! For fast physics running over the entire domain, block
    ! and thread number are not used; set to safe values
-   cdata%blk_no = 1
-   cdata%thrd_no = 1
-   cdata%thrd_cnt = 1
+   !cdata%blk_no = 1
+   !cdata%thrd_no = 1
+   !cdata%thrd_cnt = 1
 
    ! Create shared data type for fast and slow physics, one for each thread
 #ifdef OPENMP
@@ -540,10 +539,12 @@ contains
 
    if (Atm(mygrid)%flagstruct%do_sat_adj) then
       ! Initialize fast physics
-      call ccpp_physics_init(cdata, suite_name=trim(ccpp_suite), group_name="fast_physics", ierr=ierr)
+      call ccpp_physics_init(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
+           lb=Atm(mygrid)%bd%is, ub=Atm(mygrid)%bd%ie, mythread=1, &
+           nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
       if (ierr/=0) then
-         cdata%errmsg = ' atmosphere_dynamics: error in ccpp_physics_init for group fast_physics: ' // trim(cdata%errmsg)
-         call mpp_error (FATAL, cdata%errmsg)
+         errmsg = ' atmosphere_dynamics: error in ccpp_physics_init for group fast_physics: ' // trim(errmsg)
+         call mpp_error (FATAL, errmsg)
       endif
    endif
 
@@ -810,9 +811,8 @@ contains
 !! FV3 dynamical core responsible for writing out a restart and final diagnostic state.
  subroutine atmosphere_end (Time, Grid_box, restart_endfcst)
 
-   use ccpp_static_api,   only: ccpp_physics_finalize
-   use CCPP_data,         only: ccpp_suite
-   use CCPP_data,         only: cdata => cdata_tile
+   use ufs_ccpp_cap,      only: ccpp_physics_final
+   use CCPP_driver,       only: ccpp_suite, errmsg, errflg
 
    type (time_type),      intent(in)    :: Time
    type(grid_box_type),   intent(inout) :: Grid_box
@@ -821,10 +821,12 @@ contains
 
    if (Atm(mygrid)%flagstruct%do_sat_adj) then
       ! Finalize fast physics
-      call ccpp_physics_finalize(cdata, suite_name=trim(ccpp_suite), group_name="fast_physics", ierr=ierr)
+      call ccpp_physics_final(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
+           lb=Atm(mygrid)%bd%is, ub=Atm(mygrid)%bd%ie, mythread=1, &
+           nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
       if (ierr/=0) then
-         cdata%errmsg = ' atmosphere_dynamics: error in ccpp_physics_finalize for group fast_physics: ' // trim(cdata%errmsg)
-         call mpp_error (FATAL, cdata%errmsg)
+         errmsg = ' atmosphere_dynamics: error in ccpp_physics_finalize for group fast_physics: ' // trim(errmsg)
+         call mpp_error (FATAL, errmsg)
       endif
    endif
 

--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -836,7 +836,7 @@ contains
       call ccpp_physics_final(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
            lb=Atm(mygrid)%bd%is, ub=Atm(mygrid)%bd%ie, mythread=1, &
            nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
-      if (ierr/=0) then
+      if (errflg/=0) then
          errmsg = ' atmosphere_dynamics: error in ccpp_physics_finalize for group fast_physics: ' // trim(errmsg)
          call mpp_error (FATAL, errmsg)
       endif

--- a/driver/UFS/atmosphere.F90
+++ b/driver/UFS/atmosphere.F90
@@ -297,7 +297,7 @@ contains
 !! and diagnostics.
  subroutine atmosphere_init (Time_init, Time, Time_step, Grid_box, area)
 
-   use ufs_ccpp_cap,      only: ccpp_physics_init
+   use ufs_ccpp_cap,      only: ccpp_physics_init, ccpp_register, ccpp_init
    use CCPP_driver,       only: ccpp_suite, errmsg, errflg
    use CCPP_data,         only: GFDL_interstitial
 #ifdef OPENMP
@@ -538,11 +538,23 @@ contains
                                  mpirank=mpp_pe(), mpiroot=mpp_root_pe())
 
    if (Atm(mygrid)%flagstruct%do_sat_adj) then
+      ! Register fast-physics
+      call ccpp_register(ccpp_suite=trim(ccpp_suite), errflg=errflg, errmsg=errmsg)
+      if (errflg/=0) then
+         errmsg = ' atmosphere_dynamics: error in ccpp_register for group fast_physics: ' // trim(errmsg)
+         call mpp_error (FATAL, errmsg)
+      endif
+      ! Initialize ccpp
+      call ccpp_init(ccpp_suite=trim(ccpp_suite), errmsg=errmsg, errflg=errflg)
+      if (errflg/=0) then
+         errmsg = ' atmosphere_dynamics: error in ccpp_init for group fast_physics: ' // trim(errmsg)
+         call mpp_error (FATAL, errmsg)
+      endif
       ! Initialize fast physics
       call ccpp_physics_init(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
            lb=Atm(mygrid)%bd%is, ub=Atm(mygrid)%bd%ie, mythread=1, &
            nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
-      if (ierr/=0) then
+      if (errflg/=0) then
          errmsg = ' atmosphere_dynamics: error in ccpp_physics_init for group fast_physics: ' // trim(errmsg)
          call mpp_error (FATAL, errmsg)
       endif

--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -198,10 +198,9 @@ contains
                         parent_grid, domain, diss_est, inline_mp)
 
     use mpp_mod,           only: FATAL, mpp_error
-    use ccpp_static_api,   only: ccpp_physics_timestep_init,    &
-                                 ccpp_physics_timestep_finalize
-    use CCPP_data,         only: ccpp_suite
-    use CCPP_data,         only: cdata => cdata_tile
+    use ufs_ccpp_cap,      only: ccpp_physics_timestep_init,    &
+                                 ccpp_physics_timestep_final
+    use CCPP_driver,       only: ccpp_suite, errmsg, errflg
     use CCPP_data,         only: GFDL_interstitial
 
     use molecular_diffusion_mod, only: md_time, md_wait_sec, md_tadj_layers,          &
@@ -341,7 +340,8 @@ contains
       rdg = -rdgas * agrav
 
       ! Call CCPP timestep init
-      call ccpp_physics_timestep_init(cdata, suite_name=trim(ccpp_suite), group_name="fast_physics", ierr=ierr)
+      call ccpp_physics_timestep_init(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
+           lb=is, ub=ie, mythread=1, nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
       ! Reset all interstitial variables for CCPP version
       ! of fast physics, and manually set runtime parameters
       call GFDL_interstitial%reset()
@@ -1039,7 +1039,9 @@ contains
   endif
 
   ! Call CCPP timestep finalize
-  call ccpp_physics_timestep_finalize(cdata, suite_name=trim(ccpp_suite), group_name="fast_physics", ierr=ierr)
+  call ccpp_physics_timestep_final(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
+       lb=is, ub=ie, mythread=1, nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
+
 
   end subroutine fv_dynamics
 

--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -56,13 +56,17 @@ module fv_mapz_mod
 !     <td>is_master</td>
 !   </tr>
 !   <tr>
-!     <td>ccpp_static_api</td>
+!     <td>ufs_ccpp_cap</td>
 !     <td>ccpp_physics_run</td>
 !   </tr>
 !   <tr>
-!     <td>CCPP_data</td>
-!     <td>ccpp_suite, cdata_tile, GFDL_interstitial</td>
+!     <td>CCPP_driver</td>
+!     <td>ccpp_suite, errmsg, errflg</td>
 !   </tr>
+!   <tr>
+!     <td>CCPP_data</td>
+!     <td>GFDL_interstitial</td>
+!   </tr> 
 !   <tr>
 !     <td>fv_timing_mod</td>
 !     <td>timing_on, timing_off</td>
@@ -96,9 +100,8 @@ module fv_mapz_mod
   use fv_timing_mod,     only: timing_on, timing_off
   use fv_mp_mod,         only: is_master, mp_reduce_min, mp_reduce_max
   ! CCPP fast physics
-  use ccpp_static_api,   only: ccpp_physics_run
-  use CCPP_data,         only: ccpp_suite
-  use CCPP_data,         only: cdata => cdata_tile
+  use ufs_ccpp_cap,      only: ccpp_physics_run
+  use CCPP_driver,       only: ccpp_suite, errmsg, errflg
   use CCPP_data,         only: GFDL_interstitial
 #ifdef MULTI_GASES
   use multi_gases_mod,  only:  virq, virqd, vicpqd, vicvqd, num_gas
@@ -669,8 +672,8 @@ contains
 !$OMP                               ng,gridstruct,E_Flux,pdt,dtmp,reproduce_sum,q,             &
 !$OMP                               mdt,cld_amt,cappa,dtdt,out_dt,rrg,akap,do_sat_adj,         &
 !$OMP                               kord_tm, pe4,npx,npy, ccn_cm3,                             &
-!$OMP                               u_dt,v_dt,c2l_ord,bd,dp0,ps,cdata,GFDL_interstitial)       &
-!$OMP                        shared(ccpp_suite)                                                &
+!$OMP                               u_dt,v_dt,c2l_ord,bd,dp0,ps,GFDL_interstitial)             &
+!$OMP                        shared(ccpp_suite, errmsg, errflg)                                &
 #ifdef MULTI_GASES
 !$OMP                        shared(num_gas)                                                   &
 #endif
@@ -817,17 +820,18 @@ endif        ! end last_step check
 ! if ( (.not.do_adiabatic_init) .and. do_sat_adj ) then
 
   if ( do_sat_adj ) then
-                                           call timing_on('sat_adj2')
+     call timing_on('sat_adj2')
     ! Call to CCPP fast_physics group
-    if (cdata%initialized()) then
-      call ccpp_physics_run(cdata, suite_name=trim(ccpp_suite), group_name='fast_physics', ierr=ierr)
+    !if (cdata%initialized()) then
+     call ccpp_physics_run(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
+          lb=is, ub=ie, mythread=1, nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
       if (ierr/=0) then
-        call mpp_error(NOTE, trim(cdata%errmsg))
+        call mpp_error(NOTE, trim(errmsg))
         call mpp_error(FATAL, "Call to ccpp_physics_run for group 'fast_physics' failed")
       endif
-    else
-      call mpp_error (FATAL, 'Lagrangian_to_Eulerian: can not call CCPP fast physics because CCPP not initialized')
-    endif
+    !else
+    !  call mpp_error (FATAL, 'Lagrangian_to_Eulerian: can not call CCPP fast physics because CCPP not initialized')
+    !endif
                                            call timing_off('sat_adj2')
   endif   ! do_sat_adj
 

--- a/model/fv_mapz.F90
+++ b/model/fv_mapz.F90
@@ -677,7 +677,7 @@ contains
 #ifdef MULTI_GASES
 !$OMP                        shared(num_gas)                                                   &
 #endif
-!$OMP                       private(q2,pe0,pe1,pe2,pe3,qv,cvm,gz,gsize,phis,kdelz,dp2,t0, ierr)
+!$OMP                       private(q2,pe0,pe1,pe2,pe3,qv,cvm,gz,gsize,phis,kdelz,dp2,t0)
 
 !$OMP do
   do k=2,km
@@ -821,19 +821,15 @@ endif        ! end last_step check
 
   if ( do_sat_adj ) then
      call timing_on('sat_adj2')
-    ! Call to CCPP fast_physics group
-    !if (cdata%initialized()) then
+     ! Call to CCPP fast_physics group
      call ccpp_physics_run(ccpp_suite=trim(ccpp_suite), group_name='fast_physics', &
           lb=is, ub=ie, mythread=1, nthreads=1, nphys_threads=1, errflg=errflg, errmsg=errmsg)
-      if (ierr/=0) then
+      if (errflg/=0) then
         call mpp_error(NOTE, trim(errmsg))
         call mpp_error(FATAL, "Call to ccpp_physics_run for group 'fast_physics' failed")
       endif
-    !else
-    !  call mpp_error (FATAL, 'Lagrangian_to_Eulerian: can not call CCPP fast physics because CCPP not initialized')
-    !endif
-                                           call timing_off('sat_adj2')
-  endif   ! do_sat_adj
+      call timing_off('sat_adj2')
+   endif   ! do_sat_adj
 
   if ( last_step ) then
        ! Output temperature if last_step


### PR DESCRIPTION
**Description**
This PR contains the necessary changes to the CCPP fast-physics interfaces for the new code generator capgen v1. 

**How Has This Been Tested?**
All UFS weather model regression tests pass and are bit-for-bit identical.

** Dependencies
- NCAR/ccpp-framework#762
- ufs-community/ccpp-physics#378
- NOAA-EMC/ufsatm#1125
- NOAA-EMC/CMEPS#173
- ufs-community/ufs-weather-model#3288

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
