### PR TITLE
Remove number of vertical levels limit in nudging reference data

### DIFF
--- a/tools/fv_nudge.F90
+++ b/tools/fv_nudge.F90
@@ -846,8 +846,7 @@ module fv_nwp_nudge_mod
    real, intent(inout):: q(isd:ied,jsd:jed,npz,nwat)
 ! local
    real, dimension(is:ie,js:je):: ps_dt
-   integer, parameter:: kmax = 100
-   real:: pn0(kmax+1), pk0(kmax+1)
+   real:: pn0(km+1), pk0(km+1)
    real, dimension(is:ie,npz+1):: pe2, peln
    real:: pst, dbk, pt0, rdt, bias
    integer i, j, k, iq
@@ -857,7 +856,6 @@ module fv_nwp_nudge_mod
    area => gridstruct%area
 
 ! Adjust interpolated ps to model terrain
-   if ( kmax < km ) call mpp_error(FATAL,'==> KMAX must be larger than km')
 
    do j=js,je
      do i=is,ie


### PR DESCRIPTION
**Description**

Within the `ps_nudging` subroutine in `fv_nudge.F90` there is currently a limit on the number of vertical levels present in the input data.  As far as I can tell, this limit is only necessary because two local variables are defined with a hard-coded size rather than a size depending on the number of vertical levels in the input data.  This PR makes a change to remove this hard-coded limit and allow nudging to reference data with an arbitrary number of vertical levels.

**How Has This Been Tested?**

I have tested this change in a one-day nudged run it allows me to nudge to reference data with more than 100 vertical levels.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
